### PR TITLE
Update to Volt 1.5.0

### DIFF
--- a/bench/add_remove/volt.go
+++ b/bench/add_remove/volt.go
@@ -1,6 +1,7 @@
 package addremove
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/akmonengine/volt"
@@ -17,12 +18,12 @@ func runVolt(b *testing.B, n int) {
 	volt.RegisterComponent[comps.Velocity](world, &voltConfig{BuilderFn: func(component any, configuration any) {}})
 
 	for i := 0; i < n; i++ {
-		e := world.CreateEntity("-")
+		e := world.CreateEntity(strconv.Itoa(i))
 		volt.AddComponent(world, e, comps.Position{})
 	}
 
-	posMask := volt.CreateQuery1[comps.Position](world, []volt.OptionalComponent{})
-	posVelMask := volt.CreateQuery2[comps.Position, comps.Velocity](world, []volt.OptionalComponent{})
+	posMask := volt.CreateQuery1[comps.Position](world, volt.QueryConfiguration{})
+	posVelMask := volt.CreateQuery2[comps.Position, comps.Velocity](world, volt.QueryConfiguration{})
 
 	entities := make([]volt.EntityId, 0, n)
 

--- a/bench/add_remove_large/volt.go
+++ b/bench/add_remove_large/volt.go
@@ -1,6 +1,7 @@
 package addremovelarge
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/akmonengine/volt"
@@ -28,7 +29,7 @@ func runVolt(b *testing.B, n int) {
 	volt.RegisterComponent[comps.C10](world, &voltConfig{BuilderFn: func(component any, configuration any) {}})
 
 	for i := 0; i < n; i++ {
-		e, err := volt.CreateEntityWithComponents8(world, "-", comps.Position{},
+		e, err := volt.CreateEntityWithComponents8(world, strconv.Itoa(i), comps.Position{},
 			comps.C1{}, comps.C2{}, comps.C3{}, comps.C4{},
 			comps.C5{}, comps.C6{}, comps.C7{},
 		)
@@ -38,8 +39,8 @@ func runVolt(b *testing.B, n int) {
 		volt.AddComponents3(world, e, comps.C8{}, comps.C9{}, comps.C10{})
 	}
 
-	posMask := volt.CreateQuery1[comps.Position](world, []volt.OptionalComponent{})
-	posVelMask := volt.CreateQuery2[comps.Position, comps.Velocity](world, []volt.OptionalComponent{})
+	posMask := volt.CreateQuery1[comps.Position](world, volt.QueryConfiguration{})
+	posVelMask := volt.CreateQuery2[comps.Position, comps.Velocity](world, volt.QueryConfiguration{})
 
 	entities := make([]volt.EntityId, 0, n)
 

--- a/bench/create10comp/volt.go
+++ b/bench/create10comp/volt.go
@@ -1,6 +1,7 @@
 package create10comp
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/akmonengine/volt"
@@ -25,8 +26,8 @@ func runVolt(b *testing.B, n int) {
 	volt.RegisterComponent[comps.C10](world, &voltConfig{BuilderFn: func(component any, configuration any) {}})
 
 	entities := make([]volt.EntityId, 0, n)
-	for range n {
-		e, err := volt.CreateEntityWithComponents8(world, "-",
+	for id := range n {
+		e, err := volt.CreateEntityWithComponents8(world, strconv.Itoa(id),
 			comps.C1{}, comps.C2{}, comps.C3{}, comps.C4{},
 			comps.C5{}, comps.C6{}, comps.C7{}, comps.C8{},
 		)
@@ -43,8 +44,8 @@ func runVolt(b *testing.B, n int) {
 
 	for i := 0; i < b.N; i++ {
 		b.StartTimer()
-		for range n {
-			e, err := volt.CreateEntityWithComponents8(world, "-",
+		for id := range n {
+			e, err := volt.CreateEntityWithComponents8(world, strconv.Itoa(id),
 				comps.C1{}, comps.C2{}, comps.C3{}, comps.C4{},
 				comps.C5{}, comps.C6{}, comps.C7{}, comps.C8{},
 			)

--- a/bench/create2comp/volt.go
+++ b/bench/create2comp/volt.go
@@ -1,6 +1,7 @@
 package create2comp
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/akmonengine/volt"
@@ -17,8 +18,8 @@ func runVolt(b *testing.B, n int) {
 	volt.RegisterComponent[comps.Velocity](world, &voltConfig{BuilderFn: func(component any, configuration any) {}})
 
 	entities := make([]volt.EntityId, 0, n)
-	for range n {
-		e, err := volt.CreateEntityWithComponents2(world, "-", comps.Position{}, comps.Velocity{})
+	for id := range n {
+		e, err := volt.CreateEntityWithComponents2(world, strconv.Itoa(id), comps.Position{}, comps.Velocity{})
 		if err != nil {
 			panic("Volt crashed")
 		}
@@ -31,8 +32,8 @@ func runVolt(b *testing.B, n int) {
 
 	for i := 0; i < b.N; i++ {
 		b.StartTimer()
-		for range n {
-			e, err := volt.CreateEntityWithComponents2(world, "-", comps.Position{}, comps.Velocity{})
+		for id := range n {
+			e, err := volt.CreateEntityWithComponents2(world, strconv.Itoa(id), comps.Position{}, comps.Velocity{})
 			if err != nil {
 				panic("Volt crashed")
 			}

--- a/bench/create2comp_alloc/volt.go
+++ b/bench/create2comp_alloc/volt.go
@@ -1,6 +1,7 @@
 package create2compalloc
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/akmonengine/volt"
@@ -18,8 +19,8 @@ func runVolt(b *testing.B, n int) {
 		volt.RegisterComponent[comps.Velocity](world, &voltConfig{BuilderFn: func(component any, configuration any) {}})
 
 		b.StartTimer()
-		for range n {
-			_, err := volt.CreateEntityWithComponents2(world, "-", comps.Position{}, comps.Velocity{})
+		for id := range n {
+			_, err := volt.CreateEntityWithComponents2(world, strconv.Itoa(id), comps.Position{}, comps.Velocity{})
 			if err != nil {
 				panic("Volt crashed")
 			}

--- a/bench/delete10comp/volt.go
+++ b/bench/delete10comp/volt.go
@@ -1,6 +1,7 @@
 package delete10comp
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/akmonengine/volt"
@@ -25,8 +26,8 @@ func runVolt(b *testing.B, n int) {
 	volt.RegisterComponent[comps.C10](world, &voltConfig{BuilderFn: func(component any, configuration any) {}})
 
 	entities := make([]volt.EntityId, 0, n)
-	for range n {
-		e, err := volt.CreateEntityWithComponents8(world, "-",
+	for id := range n {
+		e, err := volt.CreateEntityWithComponents8(world, strconv.Itoa(id),
 			comps.C1{}, comps.C2{}, comps.C3{}, comps.C4{},
 			comps.C5{}, comps.C6{}, comps.C7{}, comps.C8{},
 		)
@@ -45,8 +46,8 @@ func runVolt(b *testing.B, n int) {
 		b.StopTimer()
 
 		entities = entities[:0]
-		for range n {
-			e, err := volt.CreateEntityWithComponents8(world, "-",
+		for id := range n {
+			e, err := volt.CreateEntityWithComponents8(world, strconv.Itoa(id),
 				comps.C1{}, comps.C2{}, comps.C3{}, comps.C4{},
 				comps.C5{}, comps.C6{}, comps.C7{}, comps.C8{},
 			)

--- a/bench/delete2comp/volt.go
+++ b/bench/delete2comp/volt.go
@@ -1,6 +1,7 @@
 package delete2comp
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/akmonengine/volt"
@@ -17,8 +18,8 @@ func runVolt(b *testing.B, n int) {
 	volt.RegisterComponent[comps.Velocity](world, &voltConfig{BuilderFn: func(component any, configuration any) {}})
 
 	entities := make([]volt.EntityId, 0, n)
-	for range n {
-		e, err := volt.CreateEntityWithComponents2(world, "-", comps.Position{}, comps.Velocity{})
+	for id := range n {
+		e, err := volt.CreateEntityWithComponents2(world, strconv.Itoa(id), comps.Position{}, comps.Velocity{})
 		if err != nil {
 			panic("Volt crashed")
 		}
@@ -33,8 +34,8 @@ func runVolt(b *testing.B, n int) {
 		b.StopTimer()
 
 		entities = entities[:0]
-		for range n {
-			e, err := volt.CreateEntityWithComponents2(world, "-", comps.Position{}, comps.Velocity{})
+		for id := range n {
+			e, err := volt.CreateEntityWithComponents2(world, strconv.Itoa(id), comps.Position{}, comps.Velocity{})
 			if err != nil {
 				panic("Volt crashed")
 			}

--- a/bench/query2comp/volt.go
+++ b/bench/query2comp/volt.go
@@ -1,6 +1,7 @@
 package query2comp
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/akmonengine/volt"
@@ -17,11 +18,11 @@ func runVolt(b *testing.B, n int) {
 	volt.RegisterComponent[comps.Velocity](world, &voltConfig{BuilderFn: func(component any, configuration any) {}})
 
 	for i := 0; i < n; i++ {
-		e := world.CreateEntity("-")
+		e := world.CreateEntity(strconv.Itoa(i))
 		volt.AddComponents2(world, e, comps.Position{}, comps.Velocity{})
 	}
 
-	query := volt.CreateQuery2[comps.Position, comps.Velocity](world, []volt.OptionalComponent{})
+	query := volt.CreateQuery2[comps.Position, comps.Velocity](world, volt.QueryConfiguration{})
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {

--- a/bench/random/volt.go
+++ b/bench/random/volt.go
@@ -3,6 +3,7 @@ package random
 import (
 	"log"
 	"math/rand/v2"
+	"strconv"
 	"testing"
 
 	"github.com/akmonengine/volt"
@@ -20,7 +21,7 @@ func runVolt(b *testing.B, n int) {
 
 	entities := make([]volt.EntityId, 0, n)
 	for i := 0; i < n; i++ {
-		e := world.CreateEntity("-")
+		e := world.CreateEntity(strconv.Itoa(i))
 		volt.AddComponent(world, e, comps.Position{})
 		entities = append(entities, e)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/mlange-42/go-ecs-benchmarks
 
-go 1.23.0
+go 1.24.0
 
 require (
-	github.com/akmonengine/volt v1.2.0
+	github.com/akmonengine/volt v1.5.0
 	github.com/marioolofo/go-gameengine-ecs v0.9.0
 	github.com/mlange-42/arche v0.15.3
 	github.com/shirou/gopsutil v3.21.11+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/akmonengine/volt v1.2.0 h1:4bFa6MFxhMobB0GyocYSABYctTtLhA4DF3lIsHuJWgo=
-github.com/akmonengine/volt v1.2.0/go.mod h1:Y35T1g6DJ8hpRbDrXEay8D/CVocJoTw77XWjFOQpaTs=
+github.com/akmonengine/volt v1.5.0 h1:Lwl3a0LwOzThB1eUNYAXeuUoo4yDvJIWivzwmZtZbpc=
+github.com/akmonengine/volt v1.5.0/go.mod h1:likSLaycVpILyqN47YGK6URulliNqwxHXeqc55FyfCo=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=


### PR DESCRIPTION
Hi, thank you for those benchmarks, they are actually useful to me, to test and try to optimize my ECS Volt.
Looking at the way you've used the module, I've seen a few errors:
- The names are supposed to be unique, even though using the string "-" for each entities did not generate errors. The relational map between names & ids would not grow accordingly: it would only overwrite the same key of the map. On 1m entities it could (positively) influence the result of the benchmarks.
- In the large benchmarks (10 components), the combination of CreateEntityWithComponents8 & AddComponents3 was not thought during the implementation of the API. AddComponentsN was supposed to be called once only, after the function CreateEntity(). The consequence (in Volt < 1.5.0) is the entity to be related to the archetype with the latest 3 components only. The first 8 components would be lost in memory. This explained the surprinsigly good result in add_remove_large. It is fixed in v1.5.0, though not optimised yet but at least the benchmark is fair now.
- Volt 1.5.0 received some performances improvements and API changes.

I have not updated the README.md and the plots, I suppose you want to execute it on your own EPYC cores for consistency ?