### PR TITLE
add simple ecs

### DIFF
--- a/bench/add_remove/run.go
+++ b/bench/add_remove/run.go
@@ -16,6 +16,7 @@ func Benchmarks() util.Benchmarks {
 			{Name: "ggecs", F: runGGEcs},
 			{Name: "uot", F: runUot},
 			{Name: "Volt", F: runVolt},
+			{Name: "Simple ECS", F: runSimpleECS},
 		},
 		N: []int{
 			1, 4, 16, 64, 256, 1024, 16_000, 256_000, 1_000_000,

--- a/bench/add_remove/simpleECS.go
+++ b/bench/add_remove/simpleECS.go
@@ -8,22 +8,23 @@ import (
 )
 
 func runSimpleECS(b *testing.B, n int) {
-	b.StopTimer()
 	world := ecs.New(n)
 	ecs.Register2[comps.Position, comps.Velocity](world)
-
 	for range n {
 		e := ecs.NewEntity(world)
 		ecs.Add(world, e, comps.Position{})
 	}
-	b.StartTimer()
+	stPosition, stVelocity := ecs.GetStorage2[comps.Position, comps.Velocity](world)
 	for b.Loop() {
-		entities := ecs.GetStorage[comps.Position](world).And(nil)
-		for _, e := range entities {
+		for _, e := range stPosition.And(nil) {
 			ecs.Add(world, e, comps.Velocity{})
 		}
-		for _, e := range entities {
+		// getting entities again is unnesessary, this is to just make it fair
+		for _, e := range stVelocity.And(stPosition) {
 			ecs.Remove[comps.Velocity](world, e)
 		}
 	}
+	entities := stPosition.And(stVelocity)
+	ecs.Kill(world, entities...)
+
 }

--- a/bench/add_remove/simpleECS.go
+++ b/bench/add_remove/simpleECS.go
@@ -1,0 +1,29 @@
+package addremove
+
+import (
+	"testing"
+
+	ecs "github.com/BrownNPC/simple-ecs"
+	"github.com/mlange-42/go-ecs-benchmarks/bench/comps"
+)
+
+func runSimpleECS(b *testing.B, n int) {
+	b.StopTimer()
+	world := ecs.New(n)
+	ecs.Register2[comps.Position, comps.Velocity](world)
+
+	for range n {
+		e := ecs.NewEntity(world)
+		ecs.Add(world, e, comps.Position{})
+	}
+	b.StartTimer()
+	for b.Loop() {
+		entities := ecs.GetStorage[comps.Position](world).And(nil)
+		for _, e := range entities {
+			ecs.Add(world, e, comps.Velocity{})
+		}
+		for _, e := range entities {
+			ecs.Remove[comps.Velocity](world, e)
+		}
+	}
+}

--- a/bench/add_remove_large/run.go
+++ b/bench/add_remove_large/run.go
@@ -16,6 +16,7 @@ func Benchmarks() util.Benchmarks {
 			{Name: "ggecs", F: runGGEcs},
 			{Name: "uot", F: runUot},
 			{Name: "Volt", F: runVolt},
+			{Name: "Simple ECS", F: runSimpleECS},
 		},
 		N: []int{
 			1, 4, 16, 64, 256, 1024, 16_000, 256_000, 1_000_000,

--- a/bench/add_remove_large/simpleECS.go
+++ b/bench/add_remove_large/simpleECS.go
@@ -8,7 +8,6 @@ import (
 )
 
 func runSimpleECS(b *testing.B, n int) {
-	b.StopTimer()
 	world := ecs.New(n)
 	// arrays will be initialized to n length, eliminating memory allocations
 	for range n {
@@ -16,16 +15,18 @@ func runSimpleECS(b *testing.B, n int) {
 		ecs.Add3(world, e, comps.Position{}, comps.C1{}, comps.C2{})
 		ecs.Add3(world, e, comps.C3{}, comps.C4{}, comps.C5{})
 		ecs.Add3(world, e, comps.C6{}, comps.C7{}, comps.C8{})
-		ecs.Add(world, e, comps.C9{})
+		ecs.Add2(world, e, comps.C9{}, comps.C10{})
 	}
-	b.StartTimer()
+	stPosition, stVelocity := ecs.GetStorage2[comps.Position, comps.Velocity](world)
 	for b.Loop() {
-		entities := ecs.GetStorage[comps.Position](world).And(nil)
-		for _, e := range entities {
+		for _, e := range stPosition.And(nil) {
 			ecs.Add(world, e, comps.Velocity{})
 		}
-		for _, e := range entities {
+		// getting entities again is unnesessary, this is to just make it fair
+		for _, e := range stVelocity.And(stPosition) {
 			ecs.Remove[comps.Velocity](world, e)
 		}
 	}
+	entities := stPosition.And(stVelocity)
+	ecs.Kill(world, entities...)
 }

--- a/bench/add_remove_large/simpleECS.go
+++ b/bench/add_remove_large/simpleECS.go
@@ -1,0 +1,32 @@
+package addremovelarge
+
+import (
+	"testing"
+
+	ecs "github.com/BrownNPC/simple-ecs"
+	"github.com/mlange-42/go-ecs-benchmarks/bench/comps"
+)
+
+func runSimpleECS(b *testing.B, n int) {
+	b.StopTimer()
+	world := ecs.New(n)
+	ecs.Register2[comps.Position, comps.Velocity](world)
+
+	for range n {
+		e := ecs.NewEntity(world)
+		ecs.Add3(world, e, comps.Position{}, comps.C1{}, comps.C2{})
+		ecs.Add3(world, e, comps.C3{}, comps.C4{}, comps.C5{})
+		ecs.Add3(world, e, comps.C6{}, comps.C7{}, comps.C8{})
+		ecs.Add(world, e, comps.C9{})
+	}
+	b.StartTimer()
+	for b.Loop() {
+		entities := ecs.GetStorage[comps.Position](world).And(nil)
+		for _, e := range entities {
+			ecs.Add(world, e, comps.Velocity{})
+		}
+		for _, e := range entities {
+			ecs.Remove[comps.Velocity](world, e)
+		}
+	}
+}

--- a/bench/add_remove_large/simpleECS.go
+++ b/bench/add_remove_large/simpleECS.go
@@ -10,8 +10,7 @@ import (
 func runSimpleECS(b *testing.B, n int) {
 	b.StopTimer()
 	world := ecs.New(n)
-	ecs.Register[comps.Position](world)
-
+	// arrays will be initialized to n length, eliminating memory allocations
 	for range n {
 		e := ecs.NewEntity(world)
 		ecs.Add3(world, e, comps.Position{}, comps.C1{}, comps.C2{})

--- a/bench/add_remove_large/simpleECS.go
+++ b/bench/add_remove_large/simpleECS.go
@@ -10,7 +10,7 @@ import (
 func runSimpleECS(b *testing.B, n int) {
 	b.StopTimer()
 	world := ecs.New(n)
-	ecs.Register2[comps.Position, comps.Velocity](world)
+	ecs.Register[comps.Position](world)
 
 	for range n {
 		e := ecs.NewEntity(world)

--- a/bench/create10comp/run.go
+++ b/bench/create10comp/run.go
@@ -16,6 +16,7 @@ func Benchmarks() util.Benchmarks {
 			{Name: "ggecs", F: runGGEcs},
 			{Name: "uot", F: runUot},
 			{Name: "Volt", F: runVolt},
+			{Name: "Simple ECS", F: runSimpleECS},
 		},
 		N: []int{
 			1, 4, 16, 64, 256, 1024, 16_000, 256_000, 1_000_000,

--- a/bench/create10comp/simpleECS.go
+++ b/bench/create10comp/simpleECS.go
@@ -8,7 +8,6 @@ import (
 )
 
 func runSimpleECS(b *testing.B, n int) {
-	b.StopTimer()
 	// initialize arrays to N length to avoid memory allocs
 	world := ecs.New(n)
 	ecs.Register2[comps.Position, comps.Velocity](world)
@@ -17,7 +16,6 @@ func runSimpleECS(b *testing.B, n int) {
 
 	entities := make([]ecs.Entity, 0, n)
 	for b.Loop() {
-		b.StartTimer()
 		for range n {
 			e := ecs.NewEntity(world)
 			ecs.Add3(world, e,
@@ -30,8 +28,7 @@ func runSimpleECS(b *testing.B, n int) {
 			ecs.Add3(world, e, comps.C7{}, comps.C8{}, comps.C9{})
 			entities = append(entities, e)
 		}
-		b.StopTimer()
-		ecs.Kill(world, entities...)
-		entities = entities[:0]
 	}
+	ecs.Kill(world, entities...)
+	entities = entities[:0]
 }

--- a/bench/create10comp/simpleECS.go
+++ b/bench/create10comp/simpleECS.go
@@ -9,20 +9,22 @@ import (
 
 func runSimpleECS(b *testing.B, n int) {
 	b.StopTimer()
-	p := ecs.New(n)
+	p := ecs.New(1024).EnableGrowing()
 	ecs.Register2[comps.Position, comps.Velocity](p)
 	ecs.Register5[comps.C1, comps.C2, comps.C3, comps.C4, comps.C5](p)
 	ecs.Register5[comps.C6, comps.C7, comps.C8, comps.C9, comps.C10](p)
 	b.StartTimer()
-	for range n {
-		e := ecs.NewEntity(p)
-		ecs.Add2(p, e,
-			comps.Position{},
-			comps.Velocity{X: 1, Y: 1},
-		)
-		ecs.Add3(p, e, comps.C1{}, comps.C2{}, comps.C3{})
-		ecs.Add3(p, e, comps.C4{}, comps.C5{}, comps.C6{})
-		ecs.Add3(p, e, comps.C7{}, comps.C8{}, comps.C9{})
-		ecs.Add(p, e, comps.C10{})
+	for b.Loop() {
+		for range n {
+			e := ecs.NewEntity(p)
+			ecs.Add2(p, e,
+				comps.Position{},
+				comps.Velocity{X: 1, Y: 1},
+			)
+			ecs.Add3(p, e, comps.C1{}, comps.C2{}, comps.C3{})
+			ecs.Add3(p, e, comps.C4{}, comps.C5{}, comps.C6{})
+			ecs.Add3(p, e, comps.C7{}, comps.C8{}, comps.C9{})
+			ecs.Add(p, e, comps.C10{})
+		}
 	}
 }

--- a/bench/create10comp/simpleECS.go
+++ b/bench/create10comp/simpleECS.go
@@ -9,22 +9,29 @@ import (
 
 func runSimpleECS(b *testing.B, n int) {
 	b.StopTimer()
-	p := ecs.New(1024).EnableGrowing()
-	ecs.Register2[comps.Position, comps.Velocity](p)
-	ecs.Register5[comps.C1, comps.C2, comps.C3, comps.C4, comps.C5](p)
-	ecs.Register5[comps.C6, comps.C7, comps.C8, comps.C9, comps.C10](p)
-	b.StartTimer()
+	// initialize arrays to N length to avoid memory allocs
+	world := ecs.New(n)
+	ecs.Register2[comps.Position, comps.Velocity](world)
+	ecs.Register5[comps.C1, comps.C2, comps.C3, comps.C4, comps.C5](world)
+	ecs.Register5[comps.C6, comps.C7, comps.C8, comps.C9, comps.C10](world)
+
+	entities := make([]ecs.Entity, 0, n)
 	for b.Loop() {
+		b.StartTimer()
 		for range n {
-			e := ecs.NewEntity(p)
-			ecs.Add2(p, e,
+			e := ecs.NewEntity(world)
+			ecs.Add3(world, e,
 				comps.Position{},
 				comps.Velocity{X: 1, Y: 1},
+				comps.C10{},
 			)
-			ecs.Add3(p, e, comps.C1{}, comps.C2{}, comps.C3{})
-			ecs.Add3(p, e, comps.C4{}, comps.C5{}, comps.C6{})
-			ecs.Add3(p, e, comps.C7{}, comps.C8{}, comps.C9{})
-			ecs.Add(p, e, comps.C10{})
+			ecs.Add3(world, e, comps.C1{}, comps.C2{}, comps.C3{})
+			ecs.Add3(world, e, comps.C4{}, comps.C5{}, comps.C6{})
+			ecs.Add3(world, e, comps.C7{}, comps.C8{}, comps.C9{})
+			entities = append(entities, e)
 		}
+		b.StopTimer()
+		ecs.Kill(world, entities...)
+		entities = entities[:0]
 	}
 }

--- a/bench/create10comp/simpleECS.go
+++ b/bench/create10comp/simpleECS.go
@@ -1,0 +1,28 @@
+package create10comp
+
+import (
+	"testing"
+
+	ecs "github.com/BrownNPC/simple-ecs"
+	"github.com/mlange-42/go-ecs-benchmarks/bench/comps"
+)
+
+func runSimpleECS(b *testing.B, n int) {
+	b.StopTimer()
+	p := ecs.New(n)
+	ecs.Register2[comps.Position, comps.Velocity](p)
+	ecs.Register5[comps.C1, comps.C2, comps.C3, comps.C4, comps.C5](p)
+	ecs.Register5[comps.C6, comps.C7, comps.C8, comps.C9, comps.C10](p)
+	b.StartTimer()
+	for range n {
+		e := ecs.NewEntity(p)
+		ecs.Add2(p, e,
+			comps.Position{},
+			comps.Velocity{X: 1, Y: 1},
+		)
+		ecs.Add3(p, e, comps.C1{}, comps.C2{}, comps.C3{})
+		ecs.Add3(p, e, comps.C4{}, comps.C5{}, comps.C6{})
+		ecs.Add3(p, e, comps.C7{}, comps.C8{}, comps.C9{})
+		ecs.Add(p, e, comps.C10{})
+	}
+}

--- a/bench/create2comp/run.go
+++ b/bench/create2comp/run.go
@@ -16,6 +16,7 @@ func Benchmarks() util.Benchmarks {
 			{Name: "ggecs", F: runGGEcs},
 			{Name: "uot", F: runUot},
 			{Name: "Volt", F: runVolt},
+			{Name: "Simple ECS", F: runSimpleECS},
 		},
 		N: []int{
 			1, 4, 16, 64, 256, 1024, 16_000, 256_000, 1_000_000,

--- a/bench/create2comp/simpleECS.go
+++ b/bench/create2comp/simpleECS.go
@@ -8,10 +8,11 @@ import (
 )
 
 func runSimpleECS(b *testing.B, n int) {
+	b.StopTimer()
+	world := ecs.New(n)
+	ecs.Register2[comps.Position,comps.Velocity](world)
 	for b.Loop() {
 		b.StartTimer()
-		world := ecs.New(1024).EnableGrowing()
-		b.StopTimer()
 		for range n {
 			e := ecs.NewEntity(world)
 			ecs.Add2(world, e,
@@ -19,5 +20,9 @@ func runSimpleECS(b *testing.B, n int) {
 				comps.Velocity{X: 1, Y: 1},
 			)
 		}
+		b.StopTimer()
+		entities := ecs.GetStorage[comps.Position](world).
+			And(ecs.GetStorage[comps.Velocity](world))
+		ecs.Kill(world, entities...)
 	}
 }

--- a/bench/create2comp/simpleECS.go
+++ b/bench/create2comp/simpleECS.go
@@ -1,0 +1,21 @@
+package create2comp
+
+import (
+	"testing"
+
+	ecs "github.com/BrownNPC/simple-ecs"
+	"github.com/mlange-42/go-ecs-benchmarks/bench/comps"
+)
+
+func runSimpleECS(b *testing.B, n int) {
+	b.StopTimer()
+	p := ecs.New(n)
+	b.StartTimer()
+	for range n {
+		e := ecs.NewEntity(p)
+		ecs.Add2(p, e,
+			comps.Position{},
+			comps.Velocity{X: 1, Y: 1},
+		)
+	}
+}

--- a/bench/create2comp/simpleECS.go
+++ b/bench/create2comp/simpleECS.go
@@ -8,21 +8,18 @@ import (
 )
 
 func runSimpleECS(b *testing.B, n int) {
-	b.StopTimer()
 	world := ecs.New(n)
-	ecs.Register2[comps.Position,comps.Velocity](world)
+	ecs.Register2[comps.Position, comps.Velocity](world)
+	entities := make([]ecs.Entity,0,n)
 	for b.Loop() {
-		b.StartTimer()
 		for range n {
 			e := ecs.NewEntity(world)
 			ecs.Add2(world, e,
 				comps.Position{},
 				comps.Velocity{X: 1, Y: 1},
 			)
+			entities = append(entities, e)
 		}
-		b.StopTimer()
-		entities := ecs.GetStorage[comps.Position](world).
-			And(ecs.GetStorage[comps.Velocity](world))
-		ecs.Kill(world, entities...)
 	}
+	ecs.Kill(world, entities...)
 }

--- a/bench/create2comp/simpleECS.go
+++ b/bench/create2comp/simpleECS.go
@@ -8,14 +8,16 @@ import (
 )
 
 func runSimpleECS(b *testing.B, n int) {
-	b.StopTimer()
-	p := ecs.New(n)
-	b.StartTimer()
-	for range n {
-		e := ecs.NewEntity(p)
-		ecs.Add2(p, e,
-			comps.Position{},
-			comps.Velocity{X: 1, Y: 1},
-		)
+	for b.Loop() {
+		b.StartTimer()
+		world := ecs.New(1024).EnableGrowing()
+		b.StopTimer()
+		for range n {
+			e := ecs.NewEntity(world)
+			ecs.Add2(world, e,
+				comps.Position{},
+				comps.Velocity{X: 1, Y: 1},
+			)
+		}
 	}
 }

--- a/bench/create2comp_alloc/run.go
+++ b/bench/create2comp_alloc/run.go
@@ -16,6 +16,7 @@ func Benchmarks() util.Benchmarks {
 			{Name: "ggecs", F: runGGEcs},
 			{Name: "uot", F: runUot},
 			{Name: "Volt", F: runVolt},
+			{Name: "Simple ECS", F: runSimpleECS},
 		},
 		N: []int{
 			1, 4, 16, 64, 256, 1024, 16_000, 256_000, 1_000_000,

--- a/bench/create2comp_alloc/simpleECS.go
+++ b/bench/create2comp_alloc/simpleECS.go
@@ -1,0 +1,22 @@
+package create2compalloc
+
+import (
+	"testing"
+
+	ecs "github.com/BrownNPC/simple-ecs"
+	"github.com/mlange-42/go-ecs-benchmarks/bench/comps"
+)
+
+func runSimpleECS(b *testing.B, n int) {
+	b.StopTimer()
+	p := ecs.New(n)
+	ecs.Register2[comps.Position, comps.Velocity](p)
+	b.StartTimer()
+	for range n {
+		e := ecs.NewEntity(p)
+		ecs.Add2(p, e,
+			comps.Position{},
+			comps.Velocity{X: 1, Y: 1},
+		)
+	}
+}

--- a/bench/create2comp_alloc/simpleECS.go
+++ b/bench/create2comp_alloc/simpleECS.go
@@ -10,7 +10,7 @@ import (
 func runSimpleECS(b *testing.B, n int) {
 	for b.Loop() {
 		b.StopTimer()
-		world := ecs.New(1024)
+		world := ecs.New(1024).EnableGrowing()
 		ecs.Register2[comps.Position, comps.Velocity](world)
 		b.StartTimer()
 		for range n {

--- a/bench/create2comp_alloc/simpleECS.go
+++ b/bench/create2comp_alloc/simpleECS.go
@@ -8,11 +8,9 @@ import (
 )
 
 func runSimpleECS(b *testing.B, n int) {
+	world := ecs.New(1024).EnableGrowing()
+	ecs.Register2[comps.Position, comps.Velocity](world)
 	for b.Loop() {
-		b.StopTimer()
-		world := ecs.New(1024).EnableGrowing()
-		ecs.Register2[comps.Position, comps.Velocity](world)
-		b.StartTimer()
 		for range n {
 			e := ecs.NewEntity(world)
 			ecs.Add2(world, e,

--- a/bench/create2comp_alloc/simpleECS.go
+++ b/bench/create2comp_alloc/simpleECS.go
@@ -8,15 +8,17 @@ import (
 )
 
 func runSimpleECS(b *testing.B, n int) {
-	b.StopTimer()
-	p := ecs.New(n)
-	ecs.Register2[comps.Position, comps.Velocity](p)
-	b.StartTimer()
-	for range n {
-		e := ecs.NewEntity(p)
-		ecs.Add2(p, e,
-			comps.Position{},
-			comps.Velocity{X: 1, Y: 1},
-		)
+	for b.Loop() {
+		b.StopTimer()
+		world := ecs.New(1024)
+		ecs.Register2[comps.Position, comps.Velocity](world)
+		b.StartTimer()
+		for range n {
+			e := ecs.NewEntity(world)
+			ecs.Add2(world, e,
+				comps.Position{},
+				comps.Velocity{X: 1, Y: 1},
+			)
+		}
 	}
 }

--- a/bench/delete10comp/run.go
+++ b/bench/delete10comp/run.go
@@ -17,7 +17,6 @@ func Benchmarks() util.Benchmarks {
 			{Name: "uot", F: runUot},
 			{Name: "Volt", F: runVolt},
 			{Name: "Simple ECS", F: runSimpleECS},
-			{Name: "Simple ECS (batch)", F: runSimpleECS_Batch},
 		},
 		N: []int{
 			1, 4, 16, 64, 256, 1024, 16_000, 256_000, 1_000_000,

--- a/bench/delete10comp/run.go
+++ b/bench/delete10comp/run.go
@@ -16,6 +16,8 @@ func Benchmarks() util.Benchmarks {
 			{Name: "ggecs", F: runGGEcs},
 			{Name: "uot", F: runUot},
 			{Name: "Volt", F: runVolt},
+			{Name: "Simple ECS", F: runSimpleECS},
+			{Name: "Simple ECS (batch)", F: runSimpleECS_Batch},
 		},
 		N: []int{
 			1, 4, 16, 64, 256, 1024, 16_000, 256_000, 1_000_000,

--- a/bench/delete10comp/simpleECS.go
+++ b/bench/delete10comp/simpleECS.go
@@ -1,0 +1,73 @@
+package delete10comp
+
+import (
+	"testing"
+
+	ecs "github.com/BrownNPC/simple-ecs"
+	"github.com/mlange-42/go-ecs-benchmarks/bench/comps"
+)
+
+func runSimpleECS(b *testing.B, n int) {
+	b.StopTimer()
+	p := ecs.New(n)
+	for range n {
+		e := ecs.NewEntity(p)
+		ecs.Add3(p, e,
+			comps.C1{}, comps.C2{}, comps.C3{},
+		)
+		ecs.Add3(p, e, comps.C4{}, comps.C5{}, comps.C6{})
+		ecs.Add3(p, e, comps.C7{}, comps.C8{}, comps.C9{})
+		ecs.Add(p, e, comps.C10{})
+	}
+	c1, c2, c3, c4, c5, c6, c7, c8, c9 := ecs.GetStorage9[comps.C1, comps.C2, comps.C3, comps.C4, comps.C5, comps.C6, comps.C7, comps.C8, comps.C9](p)
+	c10 := ecs.GetStorage[comps.C10](p)
+	for b.Loop() {
+		b.StartTimer()
+		for _, e := range c1.And(c2, c3, c4, c5, c6, c7, c8, c9, c10) {
+			ecs.Kill(p, e)
+		}
+		b.StopTimer()
+		for range n {
+			e := ecs.NewEntity(p)
+			ecs.Add3(p, e,
+				comps.C1{}, comps.C2{}, comps.C3{},
+			)
+			ecs.Add3(p, e, comps.C4{}, comps.C5{}, comps.C6{})
+			ecs.Add3(p, e, comps.C7{}, comps.C8{}, comps.C9{})
+			ecs.Add(p, e, comps.C10{})
+		}
+	}
+}
+
+// modify pointers instead of copying components
+func runSimpleECS_Batch(b *testing.B, n int) {
+	b.StopTimer()
+	p := ecs.New(n)
+	for range n {
+		e := ecs.NewEntity(p)
+		ecs.Add3(p, e,
+			comps.C1{}, comps.C2{}, comps.C3{},
+		)
+		ecs.Add3(p, e, comps.C4{}, comps.C5{}, comps.C6{})
+		ecs.Add3(p, e, comps.C7{}, comps.C8{}, comps.C9{})
+		ecs.Add(p, e, comps.C10{})
+	}
+	c1, c2, c3, c4, c5, c6, c7, c8, c9 := ecs.GetStorage9[comps.C1, comps.C2, comps.C3, comps.C4, comps.C5, comps.C6, comps.C7, comps.C8, comps.C9](p)
+	c10 := ecs.GetStorage[comps.C10](p)
+	for b.Loop() {
+		b.StartTimer()
+		e := c1.And(c2, c3, c4, c5, c6, c7, c8, c9, c10)
+		ecs.Kill(p, e...)
+
+		b.StopTimer()
+		for range n {
+			e := ecs.NewEntity(p)
+			ecs.Add3(p, e,
+				comps.C1{}, comps.C2{}, comps.C3{},
+			)
+			ecs.Add3(p, e, comps.C4{}, comps.C5{}, comps.C6{})
+			ecs.Add3(p, e, comps.C7{}, comps.C8{}, comps.C9{})
+			ecs.Add(p, e, comps.C10{})
+		}
+	}
+}

--- a/bench/delete10comp/simpleECS.go
+++ b/bench/delete10comp/simpleECS.go
@@ -1,73 +1,25 @@
 package delete10comp
 
 import (
-	"testing"
-
 	ecs "github.com/BrownNPC/simple-ecs"
 	"github.com/mlange-42/go-ecs-benchmarks/bench/comps"
+	"testing"
 )
 
 func runSimpleECS(b *testing.B, n int) {
-	b.StopTimer()
-	p := ecs.New(n)
+	world := ecs.New(n)
+	entities := make([]ecs.Entity, 0, n)
 	for range n {
-		e := ecs.NewEntity(p)
-		ecs.Add3(p, e,
-			comps.C1{}, comps.C2{}, comps.C3{},
-		)
-		ecs.Add3(p, e, comps.C4{}, comps.C5{}, comps.C6{})
-		ecs.Add3(p, e, comps.C7{}, comps.C8{}, comps.C9{})
-		ecs.Add(p, e, comps.C10{})
+		e := ecs.NewEntity(world)
+		ecs.Add3(world, e, comps.C1{}, comps.C2{}, comps.C3{})
+		ecs.Add3(world, e, comps.C4{}, comps.C5{}, comps.C6{})
+		ecs.Add3(world, e, comps.C7{}, comps.C8{}, comps.C9{})
+		ecs.Add(world, e, comps.C10{})
+		entities = append(entities, e)
 	}
-	c1, c2, c3, c4, c5, c6, c7, c8, c9 := ecs.GetStorage9[comps.C1, comps.C2, comps.C3, comps.C4, comps.C5, comps.C6, comps.C7, comps.C8, comps.C9](p)
-	c10 := ecs.GetStorage[comps.C10](p)
 	for b.Loop() {
-		b.StartTimer()
-		for _, e := range c1.And(c2, c3, c4, c5, c6, c7, c8, c9, c10) {
-			ecs.Kill(p, e)
-		}
-		b.StopTimer()
-		for range n {
-			e := ecs.NewEntity(p)
-			ecs.Add3(p, e,
-				comps.C1{}, comps.C2{}, comps.C3{},
-			)
-			ecs.Add3(p, e, comps.C4{}, comps.C5{}, comps.C6{})
-			ecs.Add3(p, e, comps.C7{}, comps.C8{}, comps.C9{})
-			ecs.Add(p, e, comps.C10{})
-		}
-	}
-}
-
-// modify pointers instead of copying components
-func runSimpleECS_Batch(b *testing.B, n int) {
-	b.StopTimer()
-	p := ecs.New(n)
-	for range n {
-		e := ecs.NewEntity(p)
-		ecs.Add3(p, e,
-			comps.C1{}, comps.C2{}, comps.C3{},
-		)
-		ecs.Add3(p, e, comps.C4{}, comps.C5{}, comps.C6{})
-		ecs.Add3(p, e, comps.C7{}, comps.C8{}, comps.C9{})
-		ecs.Add(p, e, comps.C10{})
-	}
-	c1, c2, c3, c4, c5, c6, c7, c8, c9 := ecs.GetStorage9[comps.C1, comps.C2, comps.C3, comps.C4, comps.C5, comps.C6, comps.C7, comps.C8, comps.C9](p)
-	c10 := ecs.GetStorage[comps.C10](p)
-	for b.Loop() {
-		b.StartTimer()
-		e := c1.And(c2, c3, c4, c5, c6, c7, c8, c9, c10)
-		ecs.Kill(p, e...)
-
-		b.StopTimer()
-		for range n {
-			e := ecs.NewEntity(p)
-			ecs.Add3(p, e,
-				comps.C1{}, comps.C2{}, comps.C3{},
-			)
-			ecs.Add3(p, e, comps.C4{}, comps.C5{}, comps.C6{})
-			ecs.Add3(p, e, comps.C7{}, comps.C8{}, comps.C9{})
-			ecs.Add(p, e, comps.C10{})
+		for _, e := range entities {
+			ecs.Kill(world, e)
 		}
 	}
 }

--- a/bench/delete2comp/run.go
+++ b/bench/delete2comp/run.go
@@ -17,7 +17,6 @@ func Benchmarks() util.Benchmarks {
 			{Name: "uot", F: runUot},
 			{Name: "Volt", F: runVolt},
 			{Name: "Simple ECS", F: runSimpleECS},
-			{Name: "Simple ECS (batch)", F: runSimpleECS_Batch},
 		},
 		N: []int{
 			1, 4, 16, 64, 256, 1024, 16_000, 256_000, 1_000_000,

--- a/bench/delete2comp/run.go
+++ b/bench/delete2comp/run.go
@@ -16,6 +16,8 @@ func Benchmarks() util.Benchmarks {
 			{Name: "ggecs", F: runGGEcs},
 			{Name: "uot", F: runUot},
 			{Name: "Volt", F: runVolt},
+			{Name: "Simple ECS", F: runSimpleECS},
+			{Name: "Simple ECS (batch)", F: runSimpleECS_Batch},
 		},
 		N: []int{
 			1, 4, 16, 64, 256, 1024, 16_000, 256_000, 1_000_000,

--- a/bench/delete2comp/simpleECS.go
+++ b/bench/delete2comp/simpleECS.go
@@ -1,0 +1,65 @@
+package delete2comp
+
+import (
+	"testing"
+
+	ecs "github.com/BrownNPC/simple-ecs"
+	"github.com/mlange-42/go-ecs-benchmarks/bench/comps"
+)
+
+func runSimpleECS(b *testing.B, n int) {
+	b.StopTimer()
+	p := ecs.New(n)
+	ecs.Register2[comps.Position, comps.Velocity](p)
+	for range n {
+		e := ecs.NewEntity(p)
+		ecs.Add2(p, e,
+			comps.Position{},
+			comps.Velocity{X: 1, Y: 1},
+		)
+	}
+	POSITION, VELOCITY := ecs.GetStorage2[comps.Position, comps.Velocity](p)
+	for b.Loop() {
+		b.StartTimer()
+		for _, e := range POSITION.And(VELOCITY) {
+			ecs.Kill(p, e)
+		}
+		b.StopTimer()
+		for range n {
+			e := ecs.NewEntity(p)
+			ecs.Add2(p, e,
+				comps.Position{},
+				comps.Velocity{X: 1, Y: 1},
+			)
+		}
+	}
+}
+
+// modify pointers instead of copying components
+func runSimpleECS_Batch(b *testing.B, n int) {
+	b.StopTimer()
+	p := ecs.New(n)
+	ecs.Register2[comps.Position, comps.Velocity](p)
+	for range n {
+		e := ecs.NewEntity(p)
+		ecs.Add2(p, e,
+			comps.Position{},
+			comps.Velocity{X: 1, Y: 1},
+		)
+	}
+	POSITION, VELOCITY := ecs.GetStorage2[comps.Position, comps.Velocity](p)
+	for b.Loop() {
+		b.StartTimer()
+		e := POSITION.And(VELOCITY)
+		ecs.Kill(p, e...)
+
+		b.StopTimer()
+		for range n {
+			e := ecs.NewEntity(p)
+			ecs.Add2(p, e,
+				comps.Position{},
+				comps.Velocity{X: 1, Y: 1},
+			)
+		}
+	}
+}

--- a/bench/delete2comp/simpleECS.go
+++ b/bench/delete2comp/simpleECS.go
@@ -8,8 +8,8 @@ import (
 )
 
 func runSimpleECS(b *testing.B, n int) {
-	b.StopTimer()
-	world := ecs.New(1024).EnableGrowing()
+	world := ecs.New(n)
+	entities := make([]ecs.Entity, 0, n)
 	ecs.Register2[comps.Position, comps.Velocity](world)
 	for range n {
 		e := ecs.NewEntity(world)
@@ -17,49 +17,11 @@ func runSimpleECS(b *testing.B, n int) {
 			comps.Position{},
 			comps.Velocity{X: 1, Y: 1},
 		)
+		entities = append(entities, e)
 	}
-	stPosition, stVelocity := ecs.GetStorage2[comps.Position, comps.Velocity](world)
 	for b.Loop() {
-		entities := stPosition.And(stVelocity)
-		b.StartTimer()
 		for _, e := range entities {
 			ecs.Kill(world, e)
-		}
-		b.StopTimer()
-		for range n {
-			e := ecs.NewEntity(world)
-			ecs.Add2(world, e,
-				comps.Position{},
-				comps.Velocity{X: 1, Y: 1},
-			)
-		}
-	}
-}
-// modify pointers instead of copying components
-func runSimpleECS_Batch(b *testing.B, n int) {
-	b.StopTimer()
-	world := ecs.New(1024).EnableGrowing()
-	ecs.Register2[comps.Position, comps.Velocity](world)
-	for range n {
-		e := ecs.NewEntity(world)
-		ecs.Add2(world, e,
-			comps.Position{},
-			comps.Velocity{X: 1, Y: 1},
-		)
-	}
-	for b.Loop() {
-		stPosition, stVelocity := ecs.GetStorage2[comps.Position, comps.Velocity](world)
-		e := stPosition.And(stVelocity)
-		b.StartTimer()
-		ecs.Kill(world, e...)
-		b.StopTimer()
-
-		for range n {
-			e := ecs.NewEntity(world)
-			ecs.Add2(world, e,
-				comps.Position{},
-				comps.Velocity{X: 1, Y: 1},
-			)
 		}
 	}
 }

--- a/bench/delete2comp/simpleECS.go
+++ b/bench/delete2comp/simpleECS.go
@@ -9,54 +9,54 @@ import (
 
 func runSimpleECS(b *testing.B, n int) {
 	b.StopTimer()
-	p := ecs.New(n)
-	ecs.Register2[comps.Position, comps.Velocity](p)
+	world := ecs.New(1024).EnableGrowing()
+	ecs.Register2[comps.Position, comps.Velocity](world)
 	for range n {
-		e := ecs.NewEntity(p)
-		ecs.Add2(p, e,
+		e := ecs.NewEntity(world)
+		ecs.Add2(world, e,
 			comps.Position{},
 			comps.Velocity{X: 1, Y: 1},
 		)
 	}
-	POSITION, VELOCITY := ecs.GetStorage2[comps.Position, comps.Velocity](p)
+	stPosition, stVelocity := ecs.GetStorage2[comps.Position, comps.Velocity](world)
 	for b.Loop() {
+		entities := stPosition.And(stVelocity)
 		b.StartTimer()
-		for _, e := range POSITION.And(VELOCITY) {
-			ecs.Kill(p, e)
+		for _, e := range entities {
+			ecs.Kill(world, e)
 		}
 		b.StopTimer()
 		for range n {
-			e := ecs.NewEntity(p)
-			ecs.Add2(p, e,
+			e := ecs.NewEntity(world)
+			ecs.Add2(world, e,
 				comps.Position{},
 				comps.Velocity{X: 1, Y: 1},
 			)
 		}
 	}
 }
-
 // modify pointers instead of copying components
 func runSimpleECS_Batch(b *testing.B, n int) {
 	b.StopTimer()
-	p := ecs.New(n)
-	ecs.Register2[comps.Position, comps.Velocity](p)
+	world := ecs.New(1024).EnableGrowing()
+	ecs.Register2[comps.Position, comps.Velocity](world)
 	for range n {
-		e := ecs.NewEntity(p)
-		ecs.Add2(p, e,
+		e := ecs.NewEntity(world)
+		ecs.Add2(world, e,
 			comps.Position{},
 			comps.Velocity{X: 1, Y: 1},
 		)
 	}
-	POSITION, VELOCITY := ecs.GetStorage2[comps.Position, comps.Velocity](p)
 	for b.Loop() {
+		stPosition, stVelocity := ecs.GetStorage2[comps.Position, comps.Velocity](world)
+		e := stPosition.And(stVelocity)
 		b.StartTimer()
-		e := POSITION.And(VELOCITY)
-		ecs.Kill(p, e...)
-
+		ecs.Kill(world, e...)
 		b.StopTimer()
+
 		for range n {
-			e := ecs.NewEntity(p)
-			ecs.Add2(p, e,
+			e := ecs.NewEntity(world)
+			ecs.Add2(world, e,
 				comps.Position{},
 				comps.Velocity{X: 1, Y: 1},
 			)

--- a/bench/new_world/run.go
+++ b/bench/new_world/run.go
@@ -14,6 +14,7 @@ func Benchmarks() util.Benchmarks {
 			{Name: "ggecs", F: runGGEcs},
 			{Name: "uot", F: runUot},
 			{Name: "Volt", F: runVolt},
+			{Name: "Simple ECS", F: runSimpleECS},
 		},
 		N: []int{
 			1,

--- a/bench/new_world/simpleECS.go
+++ b/bench/new_world/simpleECS.go
@@ -1,0 +1,16 @@
+package newworld
+
+import (
+	"testing"
+
+	ecs "github.com/BrownNPC/simple-ecs"
+	"github.com/stretchr/testify/assert"
+)
+
+func runSimpleECS(b *testing.B, n int) {
+	var world *ecs.Pool
+	for b.Loop() {
+		world = ecs.New(1024)
+	}
+	assert.NotNil(b, world)
+}

--- a/bench/query256arch/simpleECS.go
+++ b/bench/query256arch/simpleECS.go
@@ -1,0 +1,80 @@
+package query256arch
+
+import (
+	"testing"
+
+	ecs "github.com/BrownNPC/simple-ecs"
+	"github.com/mlange-42/go-ecs-benchmarks/bench/comps"
+)
+
+func runSimpleECS(b *testing.B, n int) {
+	// we could also initialize to n, decreasing setup time
+	world := ecs.New(1024).EnableGrowing()
+	//C1 to C8
+	extraComponents := 8
+	for i := range n * 4 {
+		e := ecs.NewEntity(world)
+		ecs.Add2(world, e, comps.Position{}, comps.Velocity{})
+
+		for componentNum := range extraComponents {
+			mask := 1 << componentNum
+			if i&mask == mask {
+				addComponent_C1toC8(world, e, componentNum)
+			}
+		}
+	}
+	stPosition, stVelocity := ecs.GetStorage2[comps.Position, comps.Velocity](world)
+	for b.Loop() {
+		for _, e := range stPosition.And(stVelocity) {
+			pos, vel := stPosition.Get(e), stVelocity.Get(e)
+			pos.X += vel.X
+			pos.Y += vel.Y
+			stPosition.Update(e, pos)
+		}
+	}
+}
+func runSimpleECS_Ptr(b *testing.B, n int) {
+	// we could also initialize to n, decreasing setup time
+	world := ecs.New(1024).EnableGrowing()
+	//C1 to C8
+	extraComponents := 8
+	for i := range n * 4 {
+		e := ecs.NewEntity(world)
+		ecs.Add2(world, e, comps.Position{}, comps.Velocity{})
+
+		for componentNum := range extraComponents {
+			mask := 1 << componentNum
+			if i&mask == mask {
+				addComponent_C1toC8(world, e, componentNum)
+			}
+		}
+	}
+	stPosition, stVelocity := ecs.GetStorage2[comps.Position, comps.Velocity](world)
+	for b.Loop() {
+		for _, e := range stPosition.And(stVelocity) {
+			pos, vel := stPosition.GetPtrUnsafe(e), stVelocity.GetPtrUnsafe(e)
+			pos.X += vel.X
+			pos.Y += vel.Y
+		}
+	}
+}
+func addComponent_C1toC8(p *ecs.Pool, e ecs.Entity, componentNum int) {
+	switch componentNum {
+	case 1:
+		ecs.Add(p, e, comps.C1{})
+	case 2:
+		ecs.Add(p, e, comps.C2{})
+	case 3:
+		ecs.Add(p, e, comps.C3{})
+	case 4:
+		ecs.Add(p, e, comps.C4{})
+	case 5:
+		ecs.Add(p, e, comps.C5{})
+	case 6:
+		ecs.Add(p, e, comps.C6{})
+	case 7:
+		ecs.Add(p, e, comps.C7{})
+	case 8:
+		ecs.Add(p, e, comps.C8{})
+	}
+}

--- a/bench/query2comp/run.go
+++ b/bench/query2comp/run.go
@@ -16,6 +16,8 @@ func Benchmarks() util.Benchmarks {
 			{Name: "ggecs", F: runGGEcs},
 			{Name: "uot", F: runUot},
 			{Name: "Volt", F: runVolt},
+			{Name: "Simple ECS", F: runSimpleECS},
+			{Name: "Simple ECS (no copy)", F: runSimpleECS_Ptr},
 		},
 		N: []int{
 			1, 4, 16, 64, 256, 1024, 16_000, 256_000, 1_000_000,

--- a/bench/query2comp/simpleECS.go
+++ b/bench/query2comp/simpleECS.go
@@ -16,15 +16,14 @@ func runSimpleECS(b *testing.B, n int) {
 			comps.Velocity{X: 1, Y: 1},
 		)
 	}
-	POSITION, VELOCITY := ecs.GetStorage2[comps.Position, comps.Velocity](p)
-	query := POSITION.And(VELOCITY)
+	stPosition, stVelocity := ecs.GetStorage2[comps.Position, comps.Velocity](p)
 	for b.Loop() {
-		for _, e := range query {
+		for _, e := range stPosition.And(stVelocity){
 			pos, vel :=
-				POSITION.Get(e), VELOCITY.Get(e)
+				stPosition.Get(e), stVelocity.Get(e)
 			pos.X += vel.X
 			pos.Y += vel.Y
-			POSITION.Update(e, pos)
+			stPosition.Update(e, pos)
 		}
 	}
 }
@@ -38,12 +37,11 @@ func runSimpleECS_Ptr(b *testing.B, n int) {
 			comps.Velocity{X: 1, Y: 1},
 		)
 	}
-	POSITION, VELOCITY := ecs.GetStorage2[comps.Position, comps.Velocity](p)
-	query := POSITION.And(VELOCITY)
+	stPosition, stVelocity := ecs.GetStorage2[comps.Position, comps.Velocity](p)
 	for b.Loop() {
-		for _, e := range query {
+		for _, e := range stPosition.And(stVelocity) {
 			pos, vel :=
-				POSITION.GetPtrUnsafe(e), VELOCITY.GetPtrUnsafe(e)
+				stPosition.GetPtrUnsafe(e), stVelocity.GetPtrUnsafe(e)
 			pos.X += vel.X
 			pos.Y += vel.Y
 		}

--- a/bench/query2comp/simpleECS.go
+++ b/bench/query2comp/simpleECS.go
@@ -1,0 +1,51 @@
+package query2comp
+
+import (
+	"testing"
+
+	ecs "github.com/BrownNPC/simple-ecs"
+	"github.com/mlange-42/go-ecs-benchmarks/bench/comps"
+)
+
+func runSimpleECS(b *testing.B, n int) {
+	p := ecs.New(n)
+	for range n {
+		e := ecs.NewEntity(p)
+		ecs.Add2(p, e,
+			comps.Position{},
+			comps.Velocity{X: 1, Y: 1},
+		)
+	}
+	POSITION, VELOCITY := ecs.GetStorage2[comps.Position, comps.Velocity](p)
+	query := POSITION.And(VELOCITY)
+	for b.Loop() {
+		for _, e := range query {
+			pos, vel :=
+				POSITION.Get(e), VELOCITY.Get(e)
+			pos.X += vel.X
+			pos.Y += vel.Y
+			POSITION.Update(e, pos)
+		}
+	}
+}
+// modify pointers instead of copying components
+func runSimpleECS_Ptr(b *testing.B, n int) {
+	p := ecs.New(n)
+	for range n {
+		e := ecs.NewEntity(p)
+		ecs.Add2(p, e,
+			comps.Position{},
+			comps.Velocity{X: 1, Y: 1},
+		)
+	}
+	POSITION, VELOCITY := ecs.GetStorage2[comps.Position, comps.Velocity](p)
+	query := POSITION.And(VELOCITY)
+	for b.Loop() {
+		for _, e := range query {
+			pos, vel :=
+				POSITION.GetPtrUnsafe(e), VELOCITY.GetPtrUnsafe(e)
+			pos.X += vel.X
+			pos.Y += vel.Y
+		}
+	}
+}

--- a/bench/query2comp/simpleECS.go
+++ b/bench/query2comp/simpleECS.go
@@ -8,17 +8,17 @@ import (
 )
 
 func runSimpleECS(b *testing.B, n int) {
-	p := ecs.New(1024).EnableGrowing()
+	world := ecs.New(n)
 	for range n {
-		e := ecs.NewEntity(p)
-		ecs.Add2(p, e,
+		e := ecs.NewEntity(world)
+		ecs.Add2(world, e,
 			comps.Position{},
 			comps.Velocity{X: 1, Y: 1},
 		)
 	}
-	stPosition, stVelocity := ecs.GetStorage2[comps.Position, comps.Velocity](p)
+	stPosition, stVelocity := ecs.GetStorage2[comps.Position, comps.Velocity](world)
 	for b.Loop() {
-		for _, e := range stPosition.And(stVelocity){
+		for _, e := range stPosition.And(stVelocity) {
 			pos, vel :=
 				stPosition.Get(e), stVelocity.Get(e)
 			pos.X += vel.X
@@ -26,18 +26,21 @@ func runSimpleECS(b *testing.B, n int) {
 			stPosition.Update(e, pos)
 		}
 	}
+	ecs.Kill(world, stPosition.And(stVelocity)...)
+
 }
+
 // modify pointers instead of copying components
 func runSimpleECS_Ptr(b *testing.B, n int) {
-	p := ecs.New(1024).EnableGrowing()
+	world := ecs.New(n)
 	for range n {
-		e := ecs.NewEntity(p)
-		ecs.Add2(p, e,
+		e := ecs.NewEntity(world)
+		ecs.Add2(world, e,
 			comps.Position{},
 			comps.Velocity{X: 1, Y: 1},
 		)
 	}
-	stPosition, stVelocity := ecs.GetStorage2[comps.Position, comps.Velocity](p)
+	stPosition, stVelocity := ecs.GetStorage2[comps.Position, comps.Velocity](world)
 	for b.Loop() {
 		for _, e := range stPosition.And(stVelocity) {
 			pos, vel :=
@@ -46,4 +49,5 @@ func runSimpleECS_Ptr(b *testing.B, n int) {
 			pos.Y += vel.Y
 		}
 	}
+	ecs.Kill(world, stPosition.And(stVelocity)...)
 }

--- a/bench/query2comp/simpleECS.go
+++ b/bench/query2comp/simpleECS.go
@@ -8,7 +8,7 @@ import (
 )
 
 func runSimpleECS(b *testing.B, n int) {
-	p := ecs.New(n)
+	p := ecs.New(1024).EnableGrowing()
 	for range n {
 		e := ecs.NewEntity(p)
 		ecs.Add2(p, e,
@@ -29,7 +29,7 @@ func runSimpleECS(b *testing.B, n int) {
 }
 // modify pointers instead of copying components
 func runSimpleECS_Ptr(b *testing.B, n int) {
-	p := ecs.New(n)
+	p := ecs.New(1024).EnableGrowing()
 	for range n {
 		e := ecs.NewEntity(p)
 		ecs.Add2(p, e,

--- a/bench/query32arch/run.go
+++ b/bench/query32arch/run.go
@@ -16,6 +16,8 @@ func Benchmarks() util.Benchmarks {
 			{Name: "ggecs", F: runGGEcs},
 			{Name: "uot", F: runUot},
 			{Name: "Volt", F: runVolt},
+			{Name: "SimpleECS", F: runSimpleECS},
+			{Name: "SimpleECS (no copy)", F: runSimpleECS_Ptr},
 		},
 		N: []int{
 			1, 4, 16, 64, 256, 1024, 16_000, 256_000, 1_000_000,

--- a/bench/query32arch/simpleECS.go
+++ b/bench/query32arch/simpleECS.go
@@ -1,0 +1,68 @@
+package query32arch
+
+import (
+	"testing"
+
+	ecs "github.com/BrownNPC/simple-ecs"
+	"github.com/mlange-42/go-ecs-benchmarks/bench/comps"
+)
+
+func runSimpleECS(b *testing.B, n int) {
+	world := ecs.New(1024).EnableGrowing()
+	extraComponents := 5
+	for i := range n {
+		e := ecs.NewEntity(world)
+		ecs.Add2(world, e, comps.Position{}, comps.Velocity{})
+		for componentNum := range extraComponents {
+			mask := 1 << componentNum
+			if i&mask == mask {
+				addComponent_C1toC5(world, e, componentNum)
+			}
+		}
+	}
+	stPosition, stVelocity := ecs.GetStorage2[comps.Position, comps.Velocity](world)
+	for b.Loop() {
+		for _, e := range stPosition.And(stVelocity) {
+			pos, vel := stPosition.Get(e), stVelocity.Get(e)
+			pos.X += vel.X
+			pos.Y += vel.Y
+			stPosition.Update(e, pos)
+		}
+	}
+}
+func runSimpleECS_Ptr(b *testing.B, n int) {
+	world := ecs.New(1024).EnableGrowing()
+	extraComponents := 5
+	for i := range n {
+		e := ecs.NewEntity(world)
+		ecs.Add2(world, e, comps.Position{}, comps.Velocity{})
+		for componentNum := range extraComponents {
+			mask := 1 << componentNum
+			if i&mask == mask {
+				addComponent_C1toC5(world, e, componentNum)
+			}
+		}
+	}
+	stPosition, stVelocity := ecs.GetStorage2[comps.Position, comps.Velocity](world)
+	for b.Loop() {
+		for _, e := range stPosition.And(stVelocity) {
+			pos, vel := stPosition.GetPtrUnsafe(e), stVelocity.GetPtrUnsafe(e)
+			pos.X += vel.X
+			pos.Y += vel.Y
+		}
+	}
+}
+func addComponent_C1toC5(p *ecs.Pool, e ecs.Entity, componentNum int) {
+	switch componentNum {
+	case 1:
+		ecs.Add(p, e, comps.C1{})
+	case 2:
+		ecs.Add(p, e, comps.C2{})
+	case 3:
+		ecs.Add(p, e, comps.C3{})
+	case 4:
+		ecs.Add(p, e, comps.C4{})
+	case 5:
+		ecs.Add(p, e, comps.C5{})
+	}
+}

--- a/bench/random/run.go
+++ b/bench/random/run.go
@@ -14,6 +14,7 @@ func Benchmarks() util.Benchmarks {
 			{Name: "ggecs", F: runGGEcs},
 			{Name: "uot", F: runUot},
 			{Name: "Volt", F: runVolt},
+			{Name: "Simple ECS", F: runSimpleECS},
 		},
 		N: []int{
 			1, 4, 16, 64, 256, 1024, 16_000, 256_000, 1_000_000,

--- a/bench/random/simpleECS.go
+++ b/bench/random/simpleECS.go
@@ -1,0 +1,37 @@
+package random
+
+import (
+	"log"
+	"math/rand/v2"
+	"testing"
+
+	ecs "github.com/BrownNPC/simple-ecs"
+	"github.com/mlange-42/go-ecs-benchmarks/bench/comps"
+	"github.com/mlange-42/go-ecs-benchmarks/bench/util"
+)
+
+func runSimpleECS(b *testing.B, n int) {
+	world := ecs.New(n)
+
+	for range n {
+		e := ecs.NewEntity(world)
+		ecs.Add(world, e,
+			comps.Position{},
+		)
+	}
+	POSITION := ecs.GetStorage[comps.Position](world)
+	entities := POSITION.And(nil)
+	rand.Shuffle(n, util.Swap(entities))
+	
+
+	sum := 0.0
+	for b.Loop() {
+		for _, e := range entities {
+			pos := POSITION.Get(e)
+			sum += pos.X
+		}
+	}
+	if sum > 0 {
+		log.Fatal("error")
+	}
+}

--- a/bench/random/simpleECS.go
+++ b/bench/random/simpleECS.go
@@ -23,7 +23,6 @@ func runSimpleECS(b *testing.B, n int) {
 	entities := stPosition.And(nil)
 	rand.Shuffle(n, util.Swap(entities))
 	
-
 	sum := 0.0
 	for b.Loop() {
 		for _, e := range entities {

--- a/bench/random/simpleECS.go
+++ b/bench/random/simpleECS.go
@@ -19,15 +19,15 @@ func runSimpleECS(b *testing.B, n int) {
 			comps.Position{},
 		)
 	}
-	POSITION := ecs.GetStorage[comps.Position](world)
-	entities := POSITION.And(nil)
+	stPosition := ecs.GetStorage[comps.Position](world)
+	entities := stPosition.And(nil)
 	rand.Shuffle(n, util.Swap(entities))
 	
 
 	sum := 0.0
 	for b.Loop() {
 		for _, e := range entities {
-			pos := POSITION.Get(e)
+			pos := stPosition.Get(e)
 			sum += pos.X
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/mlange-42/go-ecs-benchmarks
 go 1.24.0
 
 require (
-	github.com/BrownNPC/simple-ecs v1.2.5
+	github.com/BrownNPC/simple-ecs v1.2.6
 	github.com/akmonengine/volt v1.6.0
 	github.com/marioolofo/go-gameengine-ecs v0.9.0
 	github.com/mlange-42/arche v0.15.3

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/mlange-42/go-ecs-benchmarks
 go 1.24.0
 
 require (
+	github.com/BrownNPC/simple-ecs v1.2.2
 	github.com/akmonengine/volt v1.6.0
 	github.com/marioolofo/go-gameengine-ecs v0.9.0
 	github.com/mlange-42/arche v0.15.3
@@ -26,4 +27,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	golang.org/x/sys v0.29.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
+replace(
+	github.com/BrownNPC/simple-ecs => ../simple-ecs
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/mlange-42/go-ecs-benchmarks
 go 1.24.0
 
 require (
-	github.com/BrownNPC/simple-ecs v1.2.3
+	github.com/BrownNPC/simple-ecs v1.2.5
 	github.com/akmonengine/volt v1.6.0
 	github.com/marioolofo/go-gameengine-ecs v0.9.0
 	github.com/mlange-42/arche v0.15.3

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/mlange-42/go-ecs-benchmarks
 go 1.24.0
 
 require (
-	github.com/BrownNPC/simple-ecs v1.2.6
+	github.com/BrownNPC/simple-ecs v1.2.7
 	github.com/akmonengine/volt v1.6.0
 	github.com/marioolofo/go-gameengine-ecs v0.9.0
 	github.com/mlange-42/arche v0.15.3

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/mlange-42/go-ecs-benchmarks
 go 1.24.0
 
 require (
-	github.com/BrownNPC/simple-ecs v1.2.2
+	github.com/BrownNPC/simple-ecs v1.2.3
 	github.com/akmonengine/volt v1.6.0
 	github.com/marioolofo/go-gameengine-ecs v0.9.0
 	github.com/mlange-42/arche v0.15.3
@@ -27,7 +27,4 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	golang.org/x/sys v0.29.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-)
-replace(
-	github.com/BrownNPC/simple-ecs => ../simple-ecs
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/BrownNPC/simple-ecs v1.2.6 h1:0UGWw03poZRhO+TiqkfkqADGlcr8bxPdaf3zuwT8BDs=
-github.com/BrownNPC/simple-ecs v1.2.6/go.mod h1:za2tJyb/GgSyo40nG1nxohU4ThHNP+pzDmAz4KkahiU=
+github.com/BrownNPC/simple-ecs v1.2.7 h1:E4i1+dQpCacL880O4Zbeq3hx8x5kbm7YbxvOjz75J7k=
+github.com/BrownNPC/simple-ecs v1.2.7/go.mod h1:za2tJyb/GgSyo40nG1nxohU4ThHNP+pzDmAz4KkahiU=
 github.com/akmonengine/volt v1.6.0 h1:iIKXjmsg3qXcFIs7IpnAogHsAf1zVOEsl1fuH46k9Ds=
 github.com/akmonengine/volt v1.6.0/go.mod h1:likSLaycVpILyqN47YGK6URulliNqwxHXeqc55FyfCo=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
-github.com/BrownNPC/simple-ecs v1.2.3 h1:whSTi22hbj1zgtdJhpvB07/o3mp4vus3mivoOeRs3ig=
-github.com/BrownNPC/simple-ecs v1.2.3/go.mod h1:za2tJyb/GgSyo40nG1nxohU4ThHNP+pzDmAz4KkahiU=
-github.com/BrownNPC/simple-ecs v1.2.5 h1:jdIiAM0KnOynTVtY6qdvXu0nJS89vIwpdKRgA6IvG5M=
-github.com/BrownNPC/simple-ecs v1.2.5/go.mod h1:za2tJyb/GgSyo40nG1nxohU4ThHNP+pzDmAz4KkahiU=
+github.com/BrownNPC/simple-ecs v1.2.6 h1:0UGWw03poZRhO+TiqkfkqADGlcr8bxPdaf3zuwT8BDs=
+github.com/BrownNPC/simple-ecs v1.2.6/go.mod h1:za2tJyb/GgSyo40nG1nxohU4ThHNP+pzDmAz4KkahiU=
 github.com/akmonengine/volt v1.6.0 h1:iIKXjmsg3qXcFIs7IpnAogHsAf1zVOEsl1fuH46k9Ds=
 github.com/akmonengine/volt v1.6.0/go.mod h1:likSLaycVpILyqN47YGK6URulliNqwxHXeqc55FyfCo=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
-github.com/BrownNPC/simple-ecs v1.2.1 h1:sCmatUmEk4pDX+BlD61MK9izrmnqKRJovLuLzZ1Uh3Q=
-github.com/BrownNPC/simple-ecs v1.2.1/go.mod h1:za2tJyb/GgSyo40nG1nxohU4ThHNP+pzDmAz4KkahiU=
-github.com/BrownNPC/simple-ecs v1.2.2 h1:uIl+qHGgFNpQVAGipb4iAooDHfxNy3ajtPXCqTBUrzk=
-github.com/BrownNPC/simple-ecs v1.2.2/go.mod h1:za2tJyb/GgSyo40nG1nxohU4ThHNP+pzDmAz4KkahiU=
+github.com/BrownNPC/simple-ecs v1.2.3 h1:whSTi22hbj1zgtdJhpvB07/o3mp4vus3mivoOeRs3ig=
+github.com/BrownNPC/simple-ecs v1.2.3/go.mod h1:za2tJyb/GgSyo40nG1nxohU4ThHNP+pzDmAz4KkahiU=
 github.com/akmonengine/volt v1.6.0 h1:iIKXjmsg3qXcFIs7IpnAogHsAf1zVOEsl1fuH46k9Ds=
 github.com/akmonengine/volt v1.6.0/go.mod h1:likSLaycVpILyqN47YGK6URulliNqwxHXeqc55FyfCo=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/BrownNPC/simple-ecs v1.2.1 h1:sCmatUmEk4pDX+BlD61MK9izrmnqKRJovLuLzZ1Uh3Q=
+github.com/BrownNPC/simple-ecs v1.2.1/go.mod h1:za2tJyb/GgSyo40nG1nxohU4ThHNP+pzDmAz4KkahiU=
+github.com/BrownNPC/simple-ecs v1.2.2 h1:uIl+qHGgFNpQVAGipb4iAooDHfxNy3ajtPXCqTBUrzk=
+github.com/BrownNPC/simple-ecs v1.2.2/go.mod h1:za2tJyb/GgSyo40nG1nxohU4ThHNP+pzDmAz4KkahiU=
 github.com/akmonengine/volt v1.6.0 h1:iIKXjmsg3qXcFIs7IpnAogHsAf1zVOEsl1fuH46k9Ds=
 github.com/akmonengine/volt v1.6.0/go.mod h1:likSLaycVpILyqN47YGK6URulliNqwxHXeqc55FyfCo=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/BrownNPC/simple-ecs v1.2.3 h1:whSTi22hbj1zgtdJhpvB07/o3mp4vus3mivoOeRs3ig=
 github.com/BrownNPC/simple-ecs v1.2.3/go.mod h1:za2tJyb/GgSyo40nG1nxohU4ThHNP+pzDmAz4KkahiU=
+github.com/BrownNPC/simple-ecs v1.2.5 h1:jdIiAM0KnOynTVtY6qdvXu0nJS89vIwpdKRgA6IvG5M=
+github.com/BrownNPC/simple-ecs v1.2.5/go.mod h1:za2tJyb/GgSyo40nG1nxohU4ThHNP+pzDmAz4KkahiU=
 github.com/akmonengine/volt v1.6.0 h1:iIKXjmsg3qXcFIs7IpnAogHsAf1zVOEsl1fuH46k9Ds=
 github.com/akmonengine/volt v1.6.0/go.mod h1:likSLaycVpILyqN47YGK6URulliNqwxHXeqc55FyfCo=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
add [Simple ECS](https://github.com/BrownNPC/simple-ecs)

I've written all the tests except for the archetype one (queryNarch) since my library does not use archetypes and the result of the query will the the same regardless of what components an entity has.

I also dont understand why there is this seemingly unnecessary computation happening in some of the benchmarks before the loop. eg in `add_remove/volt.go`
```go
func runVolt(b *testing.B, n int) {
	b.StopTimer()
	world := volt.CreateWorld(1024)

	volt.RegisterComponent[comps.Position](world, &voltConfig{BuilderFn: func(component any, configuration any) {}})
	volt.RegisterComponent[comps.Velocity](world, &voltConfig{BuilderFn: func(component any, configuration any) {}})
//why???
	for i := 0; i < n; i++ {
		e := world.CreateEntity(strconv.Itoa(i))
		volt.AddComponent(world, e, comps.Position{})
	}

	posMask := volt.CreateQuery1[comps.Position](world, volt.QueryConfiguration{})
	posVelMask := volt.CreateQuery2[comps.Position, comps.Velocity](world, volt.QueryConfiguration{})

	entities := make([]volt.EntityId, 0, n)

	// Iterate once for more fairness
	for result := range posMask.Foreach(nil) {
		entities = append(entities, result.EntityId)
	}

	for _, e := range entities {
		volt.AddComponent(world, e, comps.Velocity{})
	}

	entities = entities[:0]
	for result := range posVelMask.Foreach(nil) {
		entities = append(entities, result.EntityId)
	}
// we reset it??
	for _, e := range entities {
		volt.RemoveComponent[comps.Velocity](world, e)
	}

	entities = entities[:0]

	b.StartTimer()

	for i := 0; i < b.N; i++ {
		// ...
		}


``` 