### PR TITLE
chore: update the benchmark to Volt 1.7.0

### DIFF
--- a/bench/add_remove/volt.go
+++ b/bench/add_remove/volt.go
@@ -1,7 +1,6 @@
 package addremove
 
 import (
-	"strconv"
 	"testing"
 
 	"github.com/akmonengine/volt"
@@ -18,7 +17,7 @@ func runVolt(b *testing.B, n int) {
 
 	entities := make([]volt.EntityId, 0, n)
 	for i := 0; i < n; i++ {
-		e := world.CreateEntity(strconv.Itoa(i))
+		e := world.CreateEntity()
 		volt.AddComponent(world, e, comps.Position{})
 		entities = append(entities, e)
 	}

--- a/bench/add_remove_large/volt.go
+++ b/bench/add_remove_large/volt.go
@@ -1,7 +1,6 @@
 package addremovelarge
 
 import (
-	"strconv"
 	"testing"
 
 	"github.com/akmonengine/volt"
@@ -29,7 +28,7 @@ func runVolt(b *testing.B, n int) {
 
 	entities := make([]volt.EntityId, 0, n)
 	for i := 0; i < n; i++ {
-		e, err := volt.CreateEntityWithComponents8(world, strconv.Itoa(i), comps.Position{},
+		e, err := volt.CreateEntityWithComponents8(world, comps.Position{},
 			comps.C1{}, comps.C2{}, comps.C3{}, comps.C4{},
 			comps.C5{}, comps.C6{}, comps.C7{},
 		)

--- a/bench/create10comp/volt.go
+++ b/bench/create10comp/volt.go
@@ -1,7 +1,6 @@
 package create10comp
 
 import (
-	"strconv"
 	"testing"
 
 	"github.com/akmonengine/volt"
@@ -25,8 +24,8 @@ func runVolt(b *testing.B, n int) {
 	volt.RegisterComponent[comps.C10](world, &voltConfig{BuilderFn: func(component any, configuration any) {}})
 
 	entities := make([]volt.EntityId, 0, n)
-	for id := range n {
-		e, err := volt.CreateEntityWithComponents8(world, strconv.Itoa(id),
+	for range n {
+		e, err := volt.CreateEntityWithComponents8(world,
 			comps.C1{}, comps.C2{}, comps.C3{}, comps.C4{},
 			comps.C5{}, comps.C6{}, comps.C7{}, comps.C8{},
 		)
@@ -42,8 +41,8 @@ func runVolt(b *testing.B, n int) {
 	entities = entities[:0]
 
 	for b.Loop() {
-		for id := range n {
-			e, err := volt.CreateEntityWithComponents8(world, strconv.Itoa(id),
+		for range n {
+			e, err := volt.CreateEntityWithComponents8(world,
 				comps.C1{}, comps.C2{}, comps.C3{}, comps.C4{},
 				comps.C5{}, comps.C6{}, comps.C7{}, comps.C8{},
 			)

--- a/bench/create2comp/volt.go
+++ b/bench/create2comp/volt.go
@@ -1,7 +1,6 @@
 package create2comp
 
 import (
-	"strconv"
 	"testing"
 
 	"github.com/akmonengine/volt"
@@ -17,8 +16,8 @@ func runVolt(b *testing.B, n int) {
 	volt.RegisterComponent[comps.Velocity](world, &voltConfig{BuilderFn: func(component any, configuration any) {}})
 
 	entities := make([]volt.EntityId, 0, n)
-	for id := range n {
-		e, err := volt.CreateEntityWithComponents2(world, strconv.Itoa(id), comps.Position{}, comps.Velocity{})
+	for range n {
+		e, err := volt.CreateEntityWithComponents2(world, comps.Position{}, comps.Velocity{})
 		if err != nil {
 			panic("Volt crashed")
 		}
@@ -30,8 +29,8 @@ func runVolt(b *testing.B, n int) {
 	entities = entities[:0]
 
 	for b.Loop() {
-		for id := range n {
-			e, err := volt.CreateEntityWithComponents2(world, strconv.Itoa(id), comps.Position{}, comps.Velocity{})
+		for range n {
+			e, err := volt.CreateEntityWithComponents2(world, comps.Position{}, comps.Velocity{})
 			if err != nil {
 				panic("Volt crashed")
 			}

--- a/bench/create2comp_alloc/volt.go
+++ b/bench/create2comp_alloc/volt.go
@@ -1,7 +1,6 @@
 package create2compalloc
 
 import (
-	"strconv"
 	"testing"
 
 	"github.com/akmonengine/volt"
@@ -19,8 +18,8 @@ func runVolt(b *testing.B, n int) {
 		volt.RegisterComponent[comps.Velocity](world, &voltConfig{BuilderFn: func(component any, configuration any) {}})
 
 		b.StartTimer()
-		for id := range n {
-			_, err := volt.CreateEntityWithComponents2(world, strconv.Itoa(id), comps.Position{}, comps.Velocity{})
+		for range n {
+			_, err := volt.CreateEntityWithComponents2(world, comps.Position{}, comps.Velocity{})
 			if err != nil {
 				panic("Volt crashed")
 			}

--- a/bench/delete10comp/volt.go
+++ b/bench/delete10comp/volt.go
@@ -1,7 +1,6 @@
 package delete10comp
 
 import (
-	"strconv"
 	"testing"
 
 	"github.com/akmonengine/volt"
@@ -25,8 +24,8 @@ func runVolt(b *testing.B, n int) {
 	volt.RegisterComponent[comps.C10](world, &voltConfig{BuilderFn: func(component any, configuration any) {}})
 
 	entities := make([]volt.EntityId, 0, n)
-	for id := range n {
-		e, err := volt.CreateEntityWithComponents8(world, strconv.Itoa(id),
+	for range n {
+		e, err := volt.CreateEntityWithComponents8(world,
 			comps.C1{}, comps.C2{}, comps.C3{}, comps.C4{},
 			comps.C5{}, comps.C6{}, comps.C7{}, comps.C8{},
 		)
@@ -43,8 +42,8 @@ func runVolt(b *testing.B, n int) {
 		}
 		b.StopTimer()
 		entities = entities[:0]
-		for id := range n {
-			e, err := volt.CreateEntityWithComponents8(world, strconv.Itoa(id),
+		for range n {
+			e, err := volt.CreateEntityWithComponents8(world,
 				comps.C1{}, comps.C2{}, comps.C3{}, comps.C4{},
 				comps.C5{}, comps.C6{}, comps.C7{}, comps.C8{},
 			)

--- a/bench/delete2comp/volt.go
+++ b/bench/delete2comp/volt.go
@@ -1,7 +1,6 @@
 package delete2comp
 
 import (
-	"strconv"
 	"testing"
 
 	"github.com/akmonengine/volt"
@@ -17,8 +16,8 @@ func runVolt(b *testing.B, n int) {
 	volt.RegisterComponent[comps.Velocity](world, &voltConfig{BuilderFn: func(component any, configuration any) {}})
 
 	entities := make([]volt.EntityId, 0, n)
-	for id := range n {
-		e, err := volt.CreateEntityWithComponents2(world, strconv.Itoa(id), comps.Position{}, comps.Velocity{})
+	for range n {
+		e, err := volt.CreateEntityWithComponents2(world, comps.Position{}, comps.Velocity{})
 		if err != nil {
 			panic("Volt crashed")
 		}
@@ -31,8 +30,8 @@ func runVolt(b *testing.B, n int) {
 		}
 		b.StopTimer()
 		entities = entities[:0]
-		for id := range n {
-			e, err := volt.CreateEntityWithComponents2(world, strconv.Itoa(id), comps.Position{}, comps.Velocity{})
+		for range n {
+			e, err := volt.CreateEntityWithComponents2(world, comps.Position{}, comps.Velocity{})
 			if err != nil {
 				panic("Volt crashed")
 			}

--- a/bench/query256arch/volt.go
+++ b/bench/query256arch/volt.go
@@ -2,7 +2,6 @@ package query256arch
 
 import (
 	"runtime"
-	"strconv"
 	"testing"
 
 	"github.com/akmonengine/volt"
@@ -24,8 +23,8 @@ func runVolt(b *testing.B, n int) {
 	volt.RegisterComponent[comps.C8](world, &volt.ComponentConfig[comps.C8]{BuilderFn: func(component any, configuration any) {}})
 	extraComps := []volt.ComponentId{comps.C1Id, comps.C2Id, comps.C3Id, comps.C4Id, comps.C5Id, comps.C6Id, comps.C7Id, comps.C8Id}
 
-	for r := range n {
-		volt.CreateEntityWithComponents2(world, strconv.Itoa(r), comps.Position{}, comps.Velocity{})
+	for range n {
+		volt.CreateEntityWithComponents2(world, comps.Position{}, comps.Velocity{})
 	}
 
 	var ids []volt.ComponentIdConf
@@ -38,7 +37,7 @@ func runVolt(b *testing.B, n int) {
 			}
 		}
 
-		e := world.CreateEntity(strconv.Itoa(n + i))
+		e := world.CreateEntity()
 		world.AddComponents(e, ids...)
 		ids = ids[:0]
 	}

--- a/bench/query2comp/volt.go
+++ b/bench/query2comp/volt.go
@@ -3,7 +3,6 @@ package query2comp
 import (
 	"fmt"
 	"runtime"
-	"strconv"
 	"testing"
 
 	"github.com/akmonengine/volt"
@@ -19,11 +18,11 @@ func runVolt(b *testing.B, n int) {
 	volt.RegisterComponent[comps.Velocity](world, &voltConfig{BuilderFn: func(component any, configuration any) {}})
 
 	for i := 0; i < n*10; i++ {
-		e := world.CreateEntity(strconv.Itoa(i))
+		e := world.CreateEntity()
 		volt.AddComponent(world, e, comps.Position{})
 	}
 	for i := 0; i < n; i++ {
-		e := world.CreateEntity(strconv.Itoa(i))
+		e := world.CreateEntity()
 		volt.AddComponents2(world, e, comps.Position{}, comps.Velocity{X: 1, Y: 1})
 	}
 

--- a/bench/query32arch/volt.go
+++ b/bench/query32arch/volt.go
@@ -2,7 +2,6 @@ package query32arch
 
 import (
 	"runtime"
-	"strconv"
 	"testing"
 
 	"github.com/akmonengine/volt"
@@ -23,7 +22,7 @@ func runVolt(b *testing.B, n int) {
 
 	var ids []volt.ComponentIdConf
 	for i := 0; i < n; i++ {
-		e := world.CreateEntity(strconv.Itoa(i))
+		e := world.CreateEntity()
 
 		ids = append(ids, volt.ComponentIdConf{ComponentId: comps.PositionId}, volt.ComponentIdConf{ComponentId: comps.VelocityId})
 		for j, id := range extraComps {

--- a/bench/random/volt.go
+++ b/bench/random/volt.go
@@ -3,7 +3,6 @@ package random
 import (
 	"log"
 	"math/rand/v2"
-	"strconv"
 	"testing"
 
 	"github.com/akmonengine/volt"
@@ -20,7 +19,7 @@ func runVolt(b *testing.B, n int) {
 
 	entities := make([]volt.EntityId, 0, n)
 	for i := 0; i < n; i++ {
-		e := world.CreateEntity(strconv.Itoa(i))
+		e := world.CreateEntity()
 		volt.AddComponent(world, e, comps.Position{})
 		entities = append(entities, e)
 	}

--- a/docs/README-template.md
+++ b/docs/README-template.md
@@ -14,7 +14,7 @@ Comparative benchmarks for Go Entity Component System (ECS) implementations.
 | [Donburi](https://github.com/yottahmd/donburi) | v1.15.7 | ![GitHub Tag](https://img.shields.io/github/v/tag/yottahmd/donburi?color=blue) ![GitHub Release Date](https://img.shields.io/github/release-date/yottahmd/donburi?label=date) | ![Last commit](https://img.shields.io/github/last-commit/yottahmd/donburi) |
 | [go‑gameengine‑ecs](https://github.com/marioolofo/go-gameengine-ecs) | v0.9.0 | ![GitHub Tag](https://img.shields.io/github/v/tag/marioolofo/go-gameengine-ecs?color=blue) ![GitHub Release Date](https://img.shields.io/github/release-date/marioolofo/go-gameengine-ecs?label=date) | ![Last commit](https://img.shields.io/github/last-commit/marioolofo/go-gameengine-ecs) |
 | [unitoftime/ecs](https://github.com/unitoftime/ecs) | v0.0.3 | ![GitHub Tag](https://img.shields.io/github/v/tag/unitoftime/ecs?color=blue) ![GitHub Release Date](https://img.shields.io/github/release-date/unitoftime/ecs?label=date) | ![Last commit](https://img.shields.io/github/last-commit/unitoftime/ecs) |
-| [Volt](https://github.com/akmonengine/volt) | v1.6.0 | ![GitHub Tag](https://img.shields.io/github/v/tag/akmonengine/volt?color=blue) ![GitHub Release Date](https://img.shields.io/github/release-date/akmonengine/volt?label=date) | ![Last commit](https://img.shields.io/github/last-commit/akmonengine/volt) |
+| [Volt](https://github.com/akmonengine/volt) | v1.7.0 | ![GitHub Tag](https://img.shields.io/github/v/tag/akmonengine/volt?color=blue) ![GitHub Release Date](https://img.shields.io/github/release-date/akmonengine/volt?label=date) | ![Last commit](https://img.shields.io/github/last-commit/akmonengine/volt) |
 
 Candidates are always displayed in alphabetical order.
 
@@ -34,7 +34,7 @@ Open an issue if you want a version update.
 | [Donburi](https://github.com/yottahmd/donburi) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | [go‑gameengine‑ecs](https://github.com/marioolofo/go-gameengine-ecs) | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
 | [unitoftime/ecs](https://github.com/unitoftime/ecs) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| [Volt](https://github.com/akmonengine/volt) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| [Volt](https://github.com/akmonengine/volt) | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
 
 [1] ECS lifecycle events, allowing to react to entity creation, component addition, ...  
 [2] Faster batch operations for entity creation etc.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/mlange-42/go-ecs-benchmarks
 go 1.25.1
 
 require (
-	github.com/akmonengine/volt v1.6.0
+	github.com/akmonengine/volt v1.7.0
 	github.com/marioolofo/go-gameengine-ecs v0.9.0
 	github.com/mlange-42/arche v0.15.3
 	github.com/mlange-42/ark v0.6.3


### PR DESCRIPTION
Hi, I've updated my module Volt to improve the performances. I finally removed the naming of entities, as we discussed a few months ago. It was impactful due to a heavy usage of a map to store all the entities indexed per name. Volt should see a huge improvement on the write/delete tests. I now use a very simple version of a Pool to keep track of the entities ids available, and the world stores a slice of entities. 

It implied changing some of the api, so I applied the changes in this PR. I also added some documentation on my project to explain how to create callbacks on the events (add/remove on entity/component), so I allowed myself to add a "check" on the documentation "Features" of this benchmark.

Have a nice day.