### PR TITLE
chore(goke): update benchmarks to GOKe v1.3.x API

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Open an issue if you want a version update.
 | [Ark](https://github.com/mlange-42/ark) | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | [Donburi](https://github.com/yohamta0/donburi-ecs) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | [go‑gameengine‑ecs](https://github.com/marioolofo/go-gameengine-ecs) | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| [GOKe](https://github.com/kjkrol/goke) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| [GOKe](https://github.com/kjkrol/goke) | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ |
 | [unitoftime/ecs](https://github.com/unitoftime/ecs) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | [Volt](https://github.com/akmonengine/volt) | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
 

--- a/bench/add_remove/goke.go
+++ b/bench/add_remove/goke.go
@@ -15,10 +15,11 @@ func runGOKe(b *testing.B, n int) {
 
 	posBP := goke.NewBlueprint1[comps.Position](ecs)
 
-	entities := make([]goke.Entity, 0, n)
-	for range n {
-		entity, _ := posBP.Create()
-		entities = append(entities, entity)
+	var entities []goke.Entity
+	for page := range posBP.Create(n) {
+		for _, e := range page.Entity {
+			entities = append(entities, e)
+		}
 	}
 
 	for _, e := range entities {

--- a/bench/add_remove_large/goke.go
+++ b/bench/add_remove_large/goke.go
@@ -20,11 +20,14 @@ func runGOKe(b *testing.B, n int) {
 		comps.C6, comps.C7, comps.C8, comps.C9,
 	](ecs)
 
-	entities := make([]goke.Entity, 0, n)
-	for range n {
-		entity, _, _, _, _, _, _, _, _, _, _ := blueprint.Create()
+	var entities []goke.Entity
+	for page := range blueprint.Create(n) {
+		for _, e := range page.Entity {
+			entities = append(entities, e)
+		}
+	}
+	for _, entity := range entities {
 		goke.EnsureComponent[comps.C10](ecs, entity, c10Desc)
-		entities = append(entities, entity)
 	}
 
 	for _, e := range entities {

--- a/bench/create10comp/goke.go
+++ b/bench/create10comp/goke.go
@@ -15,7 +15,7 @@ func runGOKe(b *testing.B, n int) {
 		comps.C6, comps.C7, comps.C8, comps.C9, comps.C10,
 	](ecs)
 
-	var entities []goke.Entity
+	entities := make([]goke.Entity, 0, n)
 	for page := range blueprint.Create(n) {
 		for _, e := range page.Entity {
 			entities = append(entities, e)

--- a/bench/create10comp/goke.go
+++ b/bench/create10comp/goke.go
@@ -15,12 +15,11 @@ func runGOKe(b *testing.B, n int) {
 		comps.C6, comps.C7, comps.C8, comps.C9, comps.C10,
 	](ecs)
 
-	entities := make([]goke.Entity, 0, n)
-
-	for range n {
-		e, _, _, _, _, _, _, _, _, _, _ := blueprint.Create()
-		// Just for fairness, because the others need to do that, too.
-		entities = append(entities, e)
+	var entities []goke.Entity
+	for page := range blueprint.Create(n) {
+		for _, e := range page.Entity {
+			entities = append(entities, e)
+		}
 	}
 
 	for _, e := range entities {
@@ -29,10 +28,10 @@ func runGOKe(b *testing.B, n int) {
 	entities = entities[:0]
 
 	for b.Loop() {
-		for range n {
-			e, _, _, _, _, _, _, _, _, _, _ := blueprint.Create()
-			// Just for fairness, because the others need to do that, too.
-			entities = append(entities, e)
+		for page := range blueprint.Create(n) {
+			for _, e := range page.Entity {
+				entities = append(entities, e)
+			}
 		}
 		b.StopTimer()
 

--- a/bench/create2comp/goke.go
+++ b/bench/create2comp/goke.go
@@ -10,12 +10,12 @@ import (
 func runGOKe(b *testing.B, n int) {
 	ecs := goke.New()
 	blueprint := goke.NewBlueprint2[comps.Position, comps.Velocity](ecs)
-	entities := make([]goke.Entity, 0, n)
 
-	for range n {
-		e, _, _ := blueprint.Create()
-		// Just for fairness, because the others need to do that, too.
-		entities = append(entities, e)
+	var entities []goke.Entity
+	for page := range blueprint.Create(n) {
+		for _, e := range page.Entity {
+			entities = append(entities, e)
+		}
 	}
 
 	for _, e := range entities {
@@ -24,10 +24,10 @@ func runGOKe(b *testing.B, n int) {
 	entities = entities[:0]
 
 	for b.Loop() {
-		for range n {
-			e, _, _ := blueprint.Create()
-			// Just for fairness, because the others need to do that, too.
-			entities = append(entities, e)
+		for page := range blueprint.Create(n) {
+			for _, e := range page.Entity {
+				entities = append(entities, e)
+			}
 		}
 		b.StopTimer()
 

--- a/bench/create2comp/goke.go
+++ b/bench/create2comp/goke.go
@@ -11,7 +11,7 @@ func runGOKe(b *testing.B, n int) {
 	ecs := goke.New()
 	blueprint := goke.NewBlueprint2[comps.Position, comps.Velocity](ecs)
 
-	var entities []goke.Entity
+	entities := make([]goke.Entity, 0, n)
 	for page := range blueprint.Create(n) {
 		for _, e := range page.Entity {
 			entities = append(entities, e)

--- a/bench/create2comp_alloc/goke.go
+++ b/bench/create2comp_alloc/goke.go
@@ -15,8 +15,7 @@ func runGOKe(b *testing.B, n int) {
 		blueprint := goke.NewBlueprint2[comps.Position, comps.Velocity](ecs)
 
 		b.StartTimer()
-		for range n {
-			blueprint.Create()
+		for _ = range blueprint.Create(n) {
 		}
 	}
 }

--- a/bench/delete10comp/goke.go
+++ b/bench/delete10comp/goke.go
@@ -16,9 +16,7 @@ func runGOKe(b *testing.B, n int) {
 	](ecs)
 	var entities []goke.Entity
 	for page := range blueprint.Create(n) {
-		for _, e := range page.Entity {
-			entities = append(entities, e)
-		}
+		entities = append(entities, page.Entity...)
 	}
 
 	for b.Loop() {
@@ -29,9 +27,7 @@ func runGOKe(b *testing.B, n int) {
 
 		entities = entities[:0]
 		for page := range blueprint.Create(n) {
-			for _, e := range page.Entity {
-				entities = append(entities, e)
-			}
+			entities = append(entities, page.Entity...)
 		}
 		b.StartTimer()
 	}

--- a/bench/delete10comp/goke.go
+++ b/bench/delete10comp/goke.go
@@ -14,10 +14,11 @@ func runGOKe(b *testing.B, n int) {
 		comps.C1, comps.C2, comps.C3, comps.C4, comps.C5,
 		comps.C6, comps.C7, comps.C8, comps.C9, comps.C10,
 	](ecs)
-	entities := make([]goke.Entity, 0, n)
-	for range n {
-		e, _, _, _, _, _, _, _, _, _, _ := blueprint.Create()
-		entities = append(entities, e)
+	var entities []goke.Entity
+	for page := range blueprint.Create(n) {
+		for _, e := range page.Entity {
+			entities = append(entities, e)
+		}
 	}
 
 	for b.Loop() {
@@ -27,10 +28,10 @@ func runGOKe(b *testing.B, n int) {
 		b.StopTimer()
 
 		entities = entities[:0]
-
-		for range n {
-			e, _, _, _, _, _, _, _, _, _, _ := blueprint.Create()
-			entities = append(entities, e)
+		for page := range blueprint.Create(n) {
+			for _, e := range page.Entity {
+				entities = append(entities, e)
+			}
 		}
 		b.StartTimer()
 	}

--- a/bench/delete2comp/goke.go
+++ b/bench/delete2comp/goke.go
@@ -11,11 +11,9 @@ func runGOKe(b *testing.B, n int) {
 	ecs := goke.New()
 
 	blueprint := goke.NewBlueprint2[comps.Position, comps.Velocity](ecs)
-	var entities []goke.Entity
+	entities := make([]goke.Entity, 0, n)
 	for page := range blueprint.Create(n) {
-		for _, e := range page.Entity {
-			entities = append(entities, e)
-		}
+		entities = append(entities, page.Entity...)
 	}
 
 	for b.Loop() {
@@ -27,9 +25,7 @@ func runGOKe(b *testing.B, n int) {
 		entities = entities[:0]
 
 		for page := range blueprint.Create(n) {
-			for _, e := range page.Entity {
-				entities = append(entities, e)
-			}
+			entities = append(entities, page.Entity...)
 		}
 		b.StartTimer()
 	}

--- a/bench/delete2comp/goke.go
+++ b/bench/delete2comp/goke.go
@@ -11,10 +11,11 @@ func runGOKe(b *testing.B, n int) {
 	ecs := goke.New()
 
 	blueprint := goke.NewBlueprint2[comps.Position, comps.Velocity](ecs)
-	entities := make([]goke.Entity, 0, n)
-	for range n {
-		e, _, _ := blueprint.Create()
-		entities = append(entities, e)
+	var entities []goke.Entity
+	for page := range blueprint.Create(n) {
+		for _, e := range page.Entity {
+			entities = append(entities, e)
+		}
 	}
 
 	for b.Loop() {
@@ -25,9 +26,10 @@ func runGOKe(b *testing.B, n int) {
 
 		entities = entities[:0]
 
-		for range n {
-			e, _, _ := blueprint.Create()
-			entities = append(entities, e)
+		for page := range blueprint.Create(n) {
+			for _, e := range page.Entity {
+				entities = append(entities, e)
+			}
 		}
 		b.StartTimer()
 	}

--- a/bench/query256arch/goke.go
+++ b/bench/query256arch/goke.go
@@ -64,8 +64,9 @@ func runGOKe(b *testing.B, n int) {
 	loop := func() {
 		for page := range view.All() {
 			for i := range page.Entity {
-				page.Comp1[i].X += page.Comp2[i].X
-				page.Comp1[i].Y += page.Comp2[i].Y
+				pos, vel := &page.Comp1[i], &page.Comp2[i]
+				pos.X += vel.X
+				pos.Y += vel.Y
 			}
 		}
 	}
@@ -76,7 +77,8 @@ func runGOKe(b *testing.B, n int) {
 	sum := 0.0
 	for page := range view.All() {
 		for i := range page.Entity {
-			sum += page.Comp1[i].X + page.Comp1[i].Y
+			pos := &page.Comp1[i]
+			sum += pos.X + pos.Y
 		}
 	}
 	runtime.KeepAlive(sum)

--- a/bench/query256arch/goke.go
+++ b/bench/query256arch/goke.go
@@ -22,46 +22,51 @@ func runGOKe(b *testing.B, n int) {
 	c7ID := goke.RegisterComponent[comps.C7](ecs)
 	c8ID := goke.RegisterComponent[comps.C8](ecs)
 
-	extraIDs := []goke.ComponentDesc{c1ID, c2ID, c3ID, c4ID, c5ID, c6ID, c7ID, c8ID}
+	realBlueprint := goke.NewBlueprint2[comps.Position, comps.Velocity](ecs)
+	for page := range realBlueprint.Create(n) {
+		_ = page
+	}
 
-	blueprint := goke.NewBlueprint2[comps.Position, comps.Velocity](ecs)
-
-	for i := range n * 4 {
-		e, _, _ := blueprint.Create()
-		for j, id := range extraIDs {
-			m := 1 << j
-			if i&m == m {
-				switch id {
-				case c1ID:
-					goke.EnsureComponent[comps.C1](ecs, e, id)
-				case c2ID:
-					goke.EnsureComponent[comps.C2](ecs, e, id)
-				case c3ID:
-					goke.EnsureComponent[comps.C3](ecs, e, id)
-				case c4ID:
-					goke.EnsureComponent[comps.C4](ecs, e, id)
-				case c5ID:
-					goke.EnsureComponent[comps.C5](ecs, e, id)
-				case c6ID:
-					goke.EnsureComponent[comps.C6](ecs, e, id)
-				case c7ID:
-					goke.EnsureComponent[comps.C7](ecs, e, id)
-				case c8ID:
-					goke.EnsureComponent[comps.C8](ecs, e, id)
-				default:
-					panic("Unknown component type: " + id.Type.String())
-				}
+	noiseBlueprint := goke.NewBlueprint1[comps.Position](ecs)
+	i := 0
+	for page := range noiseBlueprint.Create(n * 4) {
+		for _, e := range page.Entity {
+			if i&(1<<0) != 0 {
+				goke.EnsureComponent[comps.C1](ecs, e, c1ID)
 			}
+			if i&(1<<1) != 0 {
+				goke.EnsureComponent[comps.C2](ecs, e, c2ID)
+			}
+			if i&(1<<2) != 0 {
+				goke.EnsureComponent[comps.C3](ecs, e, c3ID)
+			}
+			if i&(1<<3) != 0 {
+				goke.EnsureComponent[comps.C4](ecs, e, c4ID)
+			}
+			if i&(1<<4) != 0 {
+				goke.EnsureComponent[comps.C5](ecs, e, c5ID)
+			}
+			if i&(1<<5) != 0 {
+				goke.EnsureComponent[comps.C6](ecs, e, c6ID)
+			}
+			if i&(1<<6) != 0 {
+				goke.EnsureComponent[comps.C7](ecs, e, c7ID)
+			}
+			if i&(1<<7) != 0 {
+				goke.EnsureComponent[comps.C8](ecs, e, c8ID)
+			}
+			i++
 		}
 	}
 
 	view := goke.NewView2[comps.Position, comps.Velocity](ecs)
 
 	loop := func() {
-		for head := range view.Values() {
-			pos, vel := head.V1, head.V2
-			pos.X += vel.X
-			pos.Y += vel.Y
+		for page := range view.All() {
+			for i := range page.Entity {
+				page.Comp1[i].X += page.Comp2[i].X
+				page.Comp1[i].Y += page.Comp2[i].Y
+			}
 		}
 	}
 	for b.Loop() {
@@ -69,9 +74,10 @@ func runGOKe(b *testing.B, n int) {
 	}
 
 	sum := 0.0
-	for head := range view.Values() {
-		pos := head.V1
-		sum += pos.X + pos.Y
+	for page := range view.All() {
+		for i := range page.Entity {
+			sum += page.Comp1[i].X + page.Comp1[i].Y
+		}
 	}
 	runtime.KeepAlive(sum)
 }

--- a/bench/query2comp/goke.go
+++ b/bench/query2comp/goke.go
@@ -46,9 +46,8 @@ func runGOKe(b *testing.B, n int) {
 	sum := 0.0
 	for page := range view.All() {
 		for i, _ := range page.Entity {
-			pos, vel := &page.Comp1[i], &page.Comp2[i]
-			pos.X += vel.X
-			pos.Y += vel.Y
+			pos := &page.Comp1[i]
+			sum += pos.X + pos.Y
 		}
 	}
 	if sum != float64(n*b.N*2) {

--- a/bench/query2comp/goke.go
+++ b/bench/query2comp/goke.go
@@ -18,21 +18,24 @@ func runGOKe(b *testing.B, n int) {
 	posBP := goke.NewBlueprint1[comps.Position](ecs)
 	posVelBP := goke.NewBlueprint2[comps.Position, comps.Velocity](ecs)
 
-	for range n * 10 {
-		_, _ = posBP.Create()
+	for _ = range posBP.Create(n * 10) {
 	}
-	for range n {
-		_, _, v := posVelBP.Create()
-		v.X, v.Y = 1, 1
+
+	for page := range posVelBP.Create(n) {
+		for i, _ := range page.Entity {
+			page.Comp2[i].X = 1
+			page.Comp2[i].Y = 1
+		}
 	}
 
 	view := goke.NewView2[comps.Position, comps.Velocity](ecs)
 
 	loop := func() {
-		for head := range view.Values() {
-			pos, vel := head.V1, head.V2
-			pos.X += vel.X
-			pos.Y += vel.Y
+		for page := range view.All() {
+			for i, _ := range page.Entity {
+				page.Comp1[i].X += page.Comp2[i].X
+				page.Comp1[i].Y += page.Comp2[i].Y
+			}
 		}
 	}
 	for b.Loop() {
@@ -40,9 +43,10 @@ func runGOKe(b *testing.B, n int) {
 	}
 
 	sum := 0.0
-	for head := range view.Values() {
-		pos, _ := head.V1, head.V2
-		sum += pos.X + pos.Y
+	for page := range view.All() {
+		for i, _ := range page.Entity {
+			sum += page.Comp1[i].X + page.Comp1[i].Y
+		}
 	}
 	if sum != float64(n*b.N*2) {
 		panic(fmt.Sprintf("Expected sum %d, got %.2f", n*b.N*2, sum))

--- a/bench/query2comp/goke.go
+++ b/bench/query2comp/goke.go
@@ -23,8 +23,8 @@ func runGOKe(b *testing.B, n int) {
 
 	for page := range posVelBP.Create(n) {
 		for i, _ := range page.Entity {
-			page.Comp2[i].X = 1
-			page.Comp2[i].Y = 1
+			v := &page.Comp2[i]
+			v.X, v.Y = 1, 1
 		}
 	}
 
@@ -33,8 +33,9 @@ func runGOKe(b *testing.B, n int) {
 	loop := func() {
 		for page := range view.All() {
 			for i, _ := range page.Entity {
-				page.Comp1[i].X += page.Comp2[i].X
-				page.Comp1[i].Y += page.Comp2[i].Y
+				pos, vel := &page.Comp1[i], &page.Comp2[i]
+				pos.X += vel.X
+				pos.Y += vel.Y
 			}
 		}
 	}
@@ -45,7 +46,9 @@ func runGOKe(b *testing.B, n int) {
 	sum := 0.0
 	for page := range view.All() {
 		for i, _ := range page.Entity {
-			sum += page.Comp1[i].X + page.Comp1[i].Y
+			pos, vel := &page.Comp1[i], &page.Comp2[i]
+			pos.X += vel.X
+			pos.Y += vel.Y
 		}
 	}
 	if sum != float64(n*b.N*2) {

--- a/bench/query32arch/goke.go
+++ b/bench/query32arch/goke.go
@@ -20,39 +20,42 @@ func runGOKe(b *testing.B, n int) {
 	c5ID := goke.RegisterComponent[comps.C5](ecs)
 
 	extraIDs := []goke.ComponentDesc{c1ID, c2ID, c3ID, c4ID, c5ID}
-
 	blueprint := goke.NewBlueprint2[comps.Position, comps.Velocity](ecs)
 
-	for i := range n {
-		e, _, _ := blueprint.Create()
-		for j, id := range extraIDs {
-			m := 1 << j
-			if i&m == m {
-				switch id {
-				case c1ID:
-					goke.EnsureComponent[comps.C1](ecs, e, id)
-				case c2ID:
-					goke.EnsureComponent[comps.C2](ecs, e, id)
-				case c3ID:
-					goke.EnsureComponent[comps.C3](ecs, e, id)
-				case c4ID:
-					goke.EnsureComponent[comps.C4](ecs, e, id)
-				case c5ID:
-					goke.EnsureComponent[comps.C5](ecs, e, id)
-				default:
-					panic("Unknown component type: " + id.Type.String())
+	i := 0
+	for page := range blueprint.Create(n) {
+		for _, e := range page.Entity {
+			for j, id := range extraIDs {
+				m := 1 << j
+				if i&m == m {
+					switch id {
+					case c1ID:
+						goke.EnsureComponent[comps.C1](ecs, e, id)
+					case c2ID:
+						goke.EnsureComponent[comps.C2](ecs, e, id)
+					case c3ID:
+						goke.EnsureComponent[comps.C3](ecs, e, id)
+					case c4ID:
+						goke.EnsureComponent[comps.C4](ecs, e, id)
+					case c5ID:
+						goke.EnsureComponent[comps.C5](ecs, e, id)
+					default:
+						panic("Unknown component type: " + id.Type.String())
+					}
 				}
 			}
+			i++
 		}
 	}
 
 	view := goke.NewView2[comps.Position, comps.Velocity](ecs)
 
 	loop := func() {
-		for head := range view.Values() {
-			pos, vel := head.V1, head.V2
-			pos.X += vel.X
-			pos.Y += vel.Y
+		for page := range view.All() {
+			for i, _ := range page.Entity {
+				page.Comp1[i].X += page.Comp2[i].X
+				page.Comp1[i].Y += page.Comp2[i].Y
+			}
 		}
 	}
 	for b.Loop() {
@@ -60,9 +63,10 @@ func runGOKe(b *testing.B, n int) {
 	}
 
 	sum := 0.0
-	for head := range view.Values() {
-		pos := head.V1
-		sum += pos.X + pos.Y
+	for head := range view.All() {
+		for i, _ := range head.Entity {
+			sum += head.Comp1[i].X + head.Comp1[i].Y
+		}
 	}
 	runtime.KeepAlive(sum)
 }

--- a/bench/query32arch/goke.go
+++ b/bench/query32arch/goke.go
@@ -53,8 +53,9 @@ func runGOKe(b *testing.B, n int) {
 	loop := func() {
 		for page := range view.All() {
 			for i, _ := range page.Entity {
-				page.Comp1[i].X += page.Comp2[i].X
-				page.Comp1[i].Y += page.Comp2[i].Y
+				pos, vel := &page.Comp1[i], &page.Comp2[i]
+				pos.X += vel.X
+				pos.Y += vel.Y
 			}
 		}
 	}
@@ -63,9 +64,10 @@ func runGOKe(b *testing.B, n int) {
 	}
 
 	sum := 0.0
-	for head := range view.All() {
-		for i, _ := range head.Entity {
-			sum += head.Comp1[i].X + head.Comp1[i].Y
+	for page := range view.All() {
+		for i, _ := range page.Entity {
+			pos := &page.Comp1[i]
+			sum += pos.X + pos.Y
 		}
 	}
 	runtime.KeepAlive(sum)

--- a/bench/random/goke.go
+++ b/bench/random/goke.go
@@ -18,10 +18,11 @@ func runGOKe(b *testing.B, n int) {
 	blueprint := goke.NewBlueprint1[comps.Position](ecs)
 	view := goke.NewView1[comps.Position](ecs)
 
-	entities := make([]goke.Entity, 0, n)
-	for range n {
-		e, _ := blueprint.Create()
-		entities = append(entities, e)
+	var entities []goke.Entity
+	for page := range blueprint.Create(n) {
+		for _, e := range page.Entity {
+			entities = append(entities, e)
+		}
 	}
 	rand.Shuffle(n, util.Swap(entities))
 
@@ -30,8 +31,8 @@ func runGOKe(b *testing.B, n int) {
 	// the cost of calling the non-inlined callback.
 	b.ResetTimer()
 	for range b.N {
-		for head := range view.Filter(entities) {
-			pos := head.V1
+		for _, item := range view.Filter(entities) {
+			pos := item.Comp1
 			sum += pos.X
 		}
 	}

--- a/bench/random/goke.go
+++ b/bench/random/goke.go
@@ -18,11 +18,9 @@ func runGOKe(b *testing.B, n int) {
 	blueprint := goke.NewBlueprint1[comps.Position](ecs)
 	view := goke.NewView1[comps.Position](ecs)
 
-	var entities []goke.Entity
+	entities := make([]goke.Entity, 0, n)
 	for page := range blueprint.Create(n) {
-		for _, e := range page.Entity {
-			entities = append(entities, e)
-		}
+		entities = append(entities, page.Entity...)
 	}
 	rand.Shuffle(n, util.Swap(entities))
 

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/mlange-42/go-ecs-benchmarks
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/akmonengine/volt v1.7.0
-	github.com/kjkrol/goke v1.3.3
+	github.com/kjkrol/goke v1.3.4
 	github.com/marioolofo/go-gameengine-ecs v0.9.0
 	github.com/mlange-42/arche v0.15.3
 	github.com/mlange-42/ark v0.8.3
@@ -18,6 +18,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/ebitengine/purego v0.8.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
+	github.com/kjkrol/uid v0.1.1 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/mlange-42/go-ecs-benchmarks
 
-go 1.25.3
+go 1.26.3
 
 require (
 	github.com/akmonengine/volt v1.7.0
-	github.com/kjkrol/goke v1.2.6
+	github.com/kjkrol/goke v1.3.0
 	github.com/marioolofo/go-gameengine-ecs v0.9.0
 	github.com/mlange-42/arche v0.15.3
 	github.com/mlange-42/ark v0.8.3

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.3
 
 require (
 	github.com/akmonengine/volt v1.7.0
-	github.com/kjkrol/goke v1.3.0
+	github.com/kjkrol/goke v1.3.1
 	github.com/marioolofo/go-gameengine-ecs v0.9.0
 	github.com/mlange-42/arche v0.15.3
 	github.com/mlange-42/ark v0.8.3

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.3
 
 require (
 	github.com/akmonengine/volt v1.7.0
-	github.com/kjkrol/goke v1.3.2
+	github.com/kjkrol/goke v1.3.3
 	github.com/marioolofo/go-gameengine-ecs v0.9.0
 	github.com/mlange-42/arche v0.15.3
 	github.com/mlange-42/ark v0.8.3

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.3
 
 require (
 	github.com/akmonengine/volt v1.7.0
-	github.com/kjkrol/goke v1.3.1
+	github.com/kjkrol/goke v1.3.2
 	github.com/marioolofo/go-gameengine-ecs v0.9.0
 	github.com/mlange-42/arche v0.15.3
 	github.com/mlange-42/ark v0.8.3

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiU
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/kjkrol/goke v1.2.6 h1:rR4g5RkDkGeIWnLbrq8N0wHvgCwfrS8PdNBh2Tn11V4=
-github.com/kjkrol/goke v1.2.6/go.mod h1:Ggw1wQPJIIcNZIsnVktya/W5WxZpUarOdgSSsztP/N4=
+github.com/kjkrol/goke v1.3.0 h1:BpRAfD5iZLGsOWnKOIlENAIMAtbu4XJ2rs/1tN22Ygg=
+github.com/kjkrol/goke v1.3.0/go.mod h1:sqG6e0DXPFwUex6ZAwtztQoaUL75iXzrixWt+9/it/w=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/marioolofo/go-gameengine-ecs v0.9.0 h1:J0awhWBm7CVmtDa62ouA3X7uuUTS+zcENIeBwSRumvE=

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiU
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/kjkrol/goke v1.3.1 h1:g4rQK0ieKOsHv35emCM/dqnbEVojeHn4p+bygPsgFgc=
-github.com/kjkrol/goke v1.3.1/go.mod h1:sqG6e0DXPFwUex6ZAwtztQoaUL75iXzrixWt+9/it/w=
+github.com/kjkrol/goke v1.3.2 h1:dHvqXzbA4iBQsTor3DZw5d06wF/sV3FEyeQ9tyVqkLc=
+github.com/kjkrol/goke v1.3.2/go.mod h1:sqG6e0DXPFwUex6ZAwtztQoaUL75iXzrixWt+9/it/w=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/marioolofo/go-gameengine-ecs v0.9.0 h1:J0awhWBm7CVmtDa62ouA3X7uuUTS+zcENIeBwSRumvE=

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiU
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/kjkrol/goke v1.3.2 h1:dHvqXzbA4iBQsTor3DZw5d06wF/sV3FEyeQ9tyVqkLc=
-github.com/kjkrol/goke v1.3.2/go.mod h1:sqG6e0DXPFwUex6ZAwtztQoaUL75iXzrixWt+9/it/w=
+github.com/kjkrol/goke v1.3.3 h1:AUtfAV0DU8uK214RDZ6urQYPdBJt268G/NFqlkuTd3I=
+github.com/kjkrol/goke v1.3.3/go.mod h1:sqG6e0DXPFwUex6ZAwtztQoaUL75iXzrixWt+9/it/w=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/marioolofo/go-gameengine-ecs v0.9.0 h1:J0awhWBm7CVmtDa62ouA3X7uuUTS+zcENIeBwSRumvE=

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,10 @@ github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiU
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/kjkrol/goke v1.3.3 h1:AUtfAV0DU8uK214RDZ6urQYPdBJt268G/NFqlkuTd3I=
-github.com/kjkrol/goke v1.3.3/go.mod h1:sqG6e0DXPFwUex6ZAwtztQoaUL75iXzrixWt+9/it/w=
+github.com/kjkrol/goke v1.3.4 h1:B850mEg7B0ComNZPLC5WczlyclQsogiWWGFgPMs881w=
+github.com/kjkrol/goke v1.3.4/go.mod h1:JLsPyiEPidB0MHR8eRZ2rf30xyEBJn5jO4pTBUHmhkc=
+github.com/kjkrol/uid v0.1.1 h1:q/d1/ecbj1PPz7tsAWsKALU9MhgHbVabGiWjvwaPrWA=
+github.com/kjkrol/uid v0.1.1/go.mod h1:Oia1uzucXIKdTJv7GH6N1Zq4wl6T4NyETv6tNAb6kU0=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/marioolofo/go-gameengine-ecs v0.9.0 h1:J0awhWBm7CVmtDa62ouA3X7uuUTS+zcENIeBwSRumvE=

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiU
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/kjkrol/goke v1.3.0 h1:BpRAfD5iZLGsOWnKOIlENAIMAtbu4XJ2rs/1tN22Ygg=
-github.com/kjkrol/goke v1.3.0/go.mod h1:sqG6e0DXPFwUex6ZAwtztQoaUL75iXzrixWt+9/it/w=
+github.com/kjkrol/goke v1.3.1 h1:g4rQK0ieKOsHv35emCM/dqnbEVojeHn4p+bygPsgFgc=
+github.com/kjkrol/goke v1.3.1/go.mod h1:sqG6e0DXPFwUex6ZAwtztQoaUL75iXzrixWt+9/it/w=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/marioolofo/go-gameengine-ecs v0.9.0 h1:J0awhWBm7CVmtDa62ouA3X7uuUTS+zcENIeBwSRumvE=


### PR DESCRIPTION
Adapt the GOKe benchmark suite to the redesigned iteration API
introduced in goke v1.3.x:

* Replace single-entity blueprint.Create() with the batch-based
  iter.Seq[page] form: spawn entities through `for page := range
  blueprint.Create(n)` and initialize components via typed slices
  (page.Entity, page.Comp1, ...).
* Replace view.Values() / Head / Tail pattern with view.All()
  yielding SoA pages; inner loop moved to the caller side for
  SIMD-friendly access and aggressive inlining.
* Adopt the per-entity view.Filter(selected) signature returning
  iter.Seq2[int, struct{Entity, Comp1, ...}]; index lets us
  correlate skipped entries with the input slice.

Also fix the IterateMany scenario: previously all entities matched
the query (n*4 with Pos+Vel). Now it mirrors the Arche reference:
n "real" entities with Pos+Vel and n*4 "noise" entities with Pos
plus a random subset of C1..C8 (without Vel) — exercising the
mask-matching path in a dense, archetype-heavy world.
